### PR TITLE
fix: fix rustledger conformance test runner

### DIFF
--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Get rustledger version
         id: version
         run: |
-          VERSION=$(cd rustledger && cargo pkgid | cut -d# -f2 | cut -d@ -f2)
+          VERSION=$(cd rustledger && cargo metadata --no-deps --format-version 1 | python3 -c "import sys,json; pkgs=json.load(sys.stdin)['packages']; print(pkgs[0]['version'] if pkgs else 'unknown')")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Rustledger version: $VERSION"
 
@@ -143,6 +143,11 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: |
+          pip install git+https://github.com/beancount/beancount.git@master
+          pip install git+https://github.com/beancount/beanquery.git@master
 
       - name: Run conformance tests
         id: tests

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PTA Standards
 
-[![Conformance Tests](https://github.com/rustledger/pta-standards/actions/workflows/run-tests.yml/badge.svg)](https://github.com/rustledger/pta-standards/actions/workflows/run-tests.yml)
+[![Conformance Tests](https://github.com/rustledger/pta-standards/actions/workflows/conformance-tests.yml/badge.svg)](https://github.com/rustledger/pta-standards/actions/workflows/conformance-tests.yml)
 
 **Plain Text Accounting Standards**: Specifications for Beancount, Ledger, and hledger formats.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -780,7 +780,7 @@ pta-spec/
 │   │   ├── ci.yml
 │   │   ├── validate-grammars.yml
 │   │   ├── validate-schemas.yml
-│   │   ├── run-tests.yml
+│   │   ├── conformance-tests.yml
 │   │   ├── run-alloy.yml
 │   │   ├── build-docs.yml
 │   │   └── check-links.yml


### PR DESCRIPTION
## Summary

- Install beancount/beanquery Python deps in rustledger job (test harness imports them even when using the rustledger executor)
- Fix version extraction: `cargo pkgid` fails on workspace manifests, use `cargo metadata` instead

## Test plan

- [ ] Rustledger conformance tests produce actual results (not 0/0/0)
- [ ] Version is correctly extracted

🤖 Generated with [Claude Code](https://claude.com/claude-code)