### PR TITLE
fix: update rustledger executor to match actual CLI interface

### DIFF
--- a/tests/harness/runners/python/executors/rustledger.py
+++ b/tests/harness/runners/python/executors/rustledger.py
@@ -30,7 +30,7 @@ class RustledgerExecutor(BaseExecutor):
         """
         try:
             result = subprocess.run(
-                [self.binary, "check", "--json", file_path],
+                [self.binary, "check", "--format", "json", file_path],
                 capture_output=True,
                 text=True,
                 timeout=30,
@@ -40,8 +40,13 @@ class RustledgerExecutor(BaseExecutor):
             if result.stdout.strip():
                 try:
                     data = json.loads(result.stdout)
-                    errors = data.get("errors", [])
-                    return result.returncode == 0, errors, result.stdout
+                    # rustledger outputs {diagnostics: [...], error_count: N, warning_count: N}
+                    diagnostics = data.get("diagnostics", data.get("errors", []))
+                    error_diagnostics = [
+                        d for d in diagnostics if d.get("severity", "error") == "error"
+                    ]
+                    has_errors = data.get("error_count", len(error_diagnostics)) > 0
+                    return not has_errors, diagnostics, result.stdout
                 except json.JSONDecodeError:
                     # Non-JSON output, check return code
                     pass
@@ -67,7 +72,7 @@ class RustledgerExecutor(BaseExecutor):
         """
         try:
             result = subprocess.run(
-                [self.binary, "query", file_path, query, "--json"],
+                [self.binary, "query", file_path, query, "--format", "json"],
                 capture_output=True,
                 text=True,
                 timeout=30,


### PR DESCRIPTION
## Summary

All 242 rustledger conformance tests were failing with `error: unexpected argument '--json' found` because the executor was passing `--json` instead of `--format json`.

**Changes:**
- `_run_check`: `--json` → `--format json`
- `_run_query`: `--json` → `--format json`
- Parse `diagnostics` field (not `errors`) from rustledger's JSON output
- Use `error_count` from JSON to determine pass/fail

## Context

Rustledger's `check` command uses clap with `#[arg(long, short = 'f', value_enum)]` producing `--format json`, not `--json`. The JSON output structure is `{diagnostics: [...], error_count: N, warning_count: N}`, not `{errors: [...]}`.

## Test plan

- [ ] Rustledger conformance tests produce real pass/fail results instead of all-fail
- [ ] Beancount tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)