### PR TITLE
revert: restore original beancount error message expectations

### DIFF
--- a/tests/beancount/v3/bql/tests.json
+++ b/tests/beancount/v3/bql/tests.json
@@ -488,7 +488,7 @@
       },
       "expected": {
         "query": "error",
-        "error_contains": ["error"]
+        "error_contains": ["syntax"]
       },
       "tags": ["bql", "error"]
     },
@@ -501,7 +501,7 @@
       },
       "expected": {
         "query": "error",
-        "error_contains": ["nonexistent_column"]
+        "error_contains": ["not found"]
       },
       "tags": ["bql", "error"]
     },
@@ -1018,7 +1018,7 @@
       },
       "expected": {
         "query": "error",
-        "error_contains": ["unknown function"]
+        "error_contains": ["no function matches"]
       },
       "tags": ["bql", "error"]
     },

--- a/tests/beancount/v3/syntax/invalid/tests.json
+++ b/tests/beancount/v3/syntax/invalid/tests.json
@@ -156,7 +156,7 @@
       "id": "invalid-option-unknown",
       "description": "Unknown option name",
       "input": {"inline": "option \"unknown_option\" \"value\""},
-      "expected": {"parse": "error", "error_contains": ["option"]},
+      "expected": {"parse": "error", "error_contains": ["Invalid option"]},
       "tags": ["option"]
     },
     {


### PR DESCRIPTION
## Summary

Reverts the error_contains changes from PR #16. The conformance tests should match the beancount reference implementation — rustledger should align its error messages to match, not the other way around.

Tracked in rustledger/rustledger#686.

🤖 Generated with [Claude Code](https://claude.com/claude-code)