### PR TITLE
feat: validate beancount example files in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,41 @@ jobs:
           echo "## Unit Test Results" >> $GITHUB_STEP_SUMMARY
           echo "Coverage report uploaded as artifact." >> $GITHUB_STEP_SUMMARY
 
+  validate-examples:
+    name: Validate Examples
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install beancount
+        run: pip install git+https://github.com/beancount/beancount.git@master
+
+      - name: Validate beancount examples
+        run: |
+          errors=0
+          for f in examples/beancount/*.beancount; do
+            echo "Checking: $f"
+            if ! bean-check "$f"; then
+              errors=$((errors + 1))
+            fi
+          done
+          if [ "$errors" -gt 0 ]; then
+            echo "::error::$errors example file(s) have errors"
+            exit 1
+          fi
+
+      - name: Summary
+        if: always()
+        run: |
+          count=$(ls examples/beancount/*.beancount | wc -l)
+          echo "## Example Validation" >> $GITHUB_STEP_SUMMARY
+          echo "Validated **$count** beancount example files." >> $GITHUB_STEP_SUMMARY
+
   conformance-tests:
     name: Conformance Tests
     uses: ./.github/workflows/conformance-tests.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,8 @@ jobs:
           errors=0
           for f in examples/beancount/*.beancount; do
             echo "Checking: $f"
-            if ! bean-check "$f"; then
+            if ! bean-check "$f" 2>&1; then
+              echo "::error file=$f::bean-check failed"
               errors=$((errors + 1))
             fi
           done

--- a/examples/beancount/multicurrency.beancount
+++ b/examples/beancount/multicurrency.beancount
@@ -13,12 +13,12 @@ option "operating_currency" "USD"
 2024-01-01 open Income:Freelance
 2024-01-01 open Income:Currency-Gains
 
+2024-01-01 open Equity:Opening-Balances
+
 ; Opening balances
 2024-01-01 * "Opening balance"
   Assets:Bank:US-Checking            10000.00 USD
   Equity:Opening-Balances           -10000.00 USD
-
-2024-01-01 open Equity:Opening-Balances
 
 ; Convert USD to EUR
 2024-02-01 * "Wise" "Transfer USD to EUR"
@@ -28,7 +28,7 @@ option "operating_currency" "USD"
 
 ; Receive GBP freelance payment
 2024-03-15 * "UK Client Ltd" "Freelance payment"
-  Assets:Bank:UK-Account              3000.00 GBP
+  Assets:Bank:UK-Account              3000.00 GBP @ 1.2700 USD
   Income:Freelance                   -3810.00 USD
 
 ; Convert GBP to USD

--- a/examples/beancount/multicurrency.beancount
+++ b/examples/beancount/multicurrency.beancount
@@ -33,7 +33,7 @@ option "operating_currency" "USD"
 
 ; Convert GBP to USD
 2024-04-01 * "Wise" "Transfer GBP to USD"
-  Assets:Bank:US-Checking             1900.00 USD
+  Assets:Bank:US-Checking             1899.75 USD
   Expenses:Transfer-Fees                 5.25 USD
   Assets:Bank:UK-Account             -1500.00 GBP {1.2700 USD, 2024-03-15} @ 1.2700 USD
 

--- a/examples/beancount/multicurrency.beancount
+++ b/examples/beancount/multicurrency.beancount
@@ -28,14 +28,14 @@ option "operating_currency" "USD"
 
 ; Receive GBP freelance payment
 2024-03-15 * "UK Client Ltd" "Freelance payment"
-  Assets:Bank:UK-Account              3000.00 GBP @ 1.2700 USD
+  Assets:Bank:UK-Account              3000.00 GBP {1.2700 USD, 2024-03-15}
   Income:Freelance                   -3810.00 USD
 
 ; Convert GBP to USD
 2024-04-01 * "Wise" "Transfer GBP to USD"
   Assets:Bank:US-Checking             1900.00 USD
   Expenses:Transfer-Fees                 5.25 USD
-  Assets:Bank:UK-Account             -1500.00 GBP {1.2700 USD, 2024-04-01}
+  Assets:Bank:UK-Account             -1500.00 GBP {1.2700 USD, 2024-03-15} @ 1.2700 USD
 
 ; Travel spending in JPY
 2024-05-10 * "Hotel Tokyo" "Hotel accommodation"

--- a/examples/beancount/nonprofit.beancount
+++ b/examples/beancount/nonprofit.beancount
@@ -31,13 +31,13 @@ option "operating_currency" "USD"
 ; Liability accounts
 2024-01-01 open Liabilities:Deferred-Revenue
 
+2024-01-01 open Equity:Opening-Balances
+
 ; Opening balance
 2024-01-01 * "Opening balance"
   Assets:Bank:Operating              25000.00 USD
   Assets:Bank:Savings                50000.00 USD
   Equity:Opening-Balances           -75000.00 USD
-
-2024-01-01 open Equity:Opening-Balances
 
 ; Unrestricted individual donations
 2024-01-15 * "Jane Smith" "Annual donation"


### PR DESCRIPTION
## Summary

Adds a `validate-examples` CI job that runs `bean-check` on all 6 beancount example files. Catches accounting errors (unbalanced transactions, missing open directives, etc.) before they're published.

## Test plan

- [ ] All 6 beancount examples pass bean-check
- [ ] Step summary shows count of validated files

🤖 Generated with [Claude Code](https://claude.com/claude-code)