### PR TITLE
feat: add fuzzing seed corpus for all 3 formats

### DIFF
--- a/tests/fuzzing/seeds/beancount/complex.beancount
+++ b/tests/fuzzing/seeds/beancount/complex.beancount
@@ -1,0 +1,78 @@
+option "title" "Complex Fuzzing Seed"
+option "operating_currency" "USD"
+option "inferred_tolerance_default" "USD:0.005"
+
+2024-01-01 open Assets:Bank:Checking USD
+2024-01-01 open Assets:Bank:Savings USD
+2024-01-01 open Assets:Brokerage AAPL,GOOGL,VTI,USD
+2024-01-01 open Assets:Foreign EUR,GBP
+2024-01-01 open Liabilities:Credit-Card USD
+2024-01-01 open Liabilities:Mortgage USD
+2024-01-01 open Equity:Opening-Balances
+2024-01-01 open Income:Salary USD
+2024-01-01 open Income:Dividends USD
+2024-01-01 open Income:Capital-Gains USD
+2024-01-01 open Expenses:Food:Groceries USD
+2024-01-01 open Expenses:Food:Restaurant USD
+2024-01-01 open Expenses:Housing:Rent USD
+2024-01-01 open Expenses:Transport USD
+2024-01-01 open Expenses:Taxes:Federal USD
+
+; Opening balances
+2024-01-01 * "Opening"
+  Assets:Bank:Checking    50000.00 USD
+  Assets:Bank:Savings    100000.00 USD
+  Assets:Brokerage        100 AAPL {150.00 USD, 2023-06-15}
+  Assets:Brokerage         50 GOOGL {140.00 USD, 2023-09-01}
+  Assets:Brokerage        200 VTI {220.00 USD, 2023-03-01}
+  Assets:Foreign         5000.00 EUR {1.08 USD, 2023-12-01}
+  Liabilities:Mortgage -250000.00 USD
+  Equity:Opening-Balances
+
+; Multi-posting transaction with metadata
+2024-01-15 * "Employer" "Monthly salary" #income #2024
+  receipt: "pay-stub-2024-01.pdf"
+  Assets:Bank:Checking    8000.00 USD
+  Expenses:Taxes:Federal  2000.00 USD
+  Income:Salary         -10000.00 USD
+
+; Credit card with multiple expense categories
+2024-01-20 * "Various" "Weekly expenses"
+  Expenses:Food:Groceries   120.50 USD
+  Expenses:Food:Restaurant   45.00 USD
+  Expenses:Transport         35.00 USD
+  Liabilities:Credit-Card
+
+; Stock purchase with cost basis
+2024-02-01 * "Buy more AAPL"
+  Assets:Brokerage  25 AAPL {175.00 USD, 2024-02-01}
+  Assets:Bank:Checking -4375.00 USD
+
+; Stock sale with FIFO booking
+2024-03-01 * "Sell AAPL" ^trade-q1
+  Assets:Brokerage -50 AAPL {150.00 USD, 2023-06-15} @ 180.00 USD
+  Assets:Bank:Checking  9000.00 USD
+  Income:Capital-Gains
+
+; Dividend income
+2024-03-15 * "AAPL" "Q1 Dividend"
+  Assets:Bank:Checking  75.00 USD
+  Income:Dividends
+
+; Currency conversion
+2024-04-01 * "Convert EUR"
+  Assets:Bank:Checking    2700.00 USD
+  Assets:Foreign         -2500.00 EUR {1.08 USD, 2023-12-01} @ 1.08 USD
+
+; Balance assertions
+2024-06-30 balance Assets:Bank:Checking 63025.50 USD
+2024-06-30 balance Assets:Brokerage      75 AAPL
+2024-06-30 balance Assets:Brokerage      50 GOOGL
+2024-06-30 balance Assets:Brokerage     200 VTI
+
+; Prices
+2024-06-30 price AAPL  185.00 USD
+2024-06-30 price GOOGL 175.00 USD
+2024-06-30 price VTI   235.00 USD
+2024-06-30 price EUR     1.07 USD
+2024-06-30 price GBP     1.26 USD

--- a/tests/fuzzing/seeds/beancount/directives.beancount
+++ b/tests/fuzzing/seeds/beancount/directives.beancount
@@ -1,0 +1,49 @@
+option "title" "Fuzzing Seed"
+option "operating_currency" "USD"
+
+plugin "beancount.plugins.auto_accounts"
+
+2024-01-01 open Assets:Bank:Checking USD
+2024-01-01 open Assets:Cash USD
+2024-01-01 open Assets:Brokerage AAPL,USD
+2024-01-01 open Liabilities:Credit-Card USD
+2024-01-01 open Equity:Opening-Balances
+2024-01-01 open Income:Salary USD
+2024-01-01 open Expenses:Food USD
+2024-01-01 open Expenses:Rent USD
+
+2024-01-01 commodity USD
+2024-01-01 commodity AAPL
+
+2024-01-01 * "Opening" "Opening balances"
+  Assets:Bank:Checking  10000 USD
+  Equity:Opening-Balances
+
+2024-01-15 * "Employer" "Salary" #income
+  Assets:Bank:Checking  5000 USD
+  Income:Salary
+
+2024-01-20 ! "Grocery Store" "Weekly groceries"
+  Expenses:Food  85.50 USD
+  Assets:Bank:Checking
+
+2024-02-01 * "Landlord" "February rent"
+  category: "housing"
+  Expenses:Rent  1500 USD
+  Assets:Bank:Checking
+
+2024-02-15 balance Assets:Bank:Checking 13414.50 USD
+
+2024-03-01 pad Assets:Cash Equity:Opening-Balances
+
+2024-03-15 * "Buy stock" ^trade-001
+  Assets:Brokerage  10 AAPL {150.00 USD, 2024-03-15}
+  Assets:Bank:Checking -1500.00 USD
+
+2024-04-01 price AAPL 155.00 USD
+
+2024-04-15 event "location" "New York"
+
+2024-05-01 note Assets:Bank:Checking "Account upgraded to premium"
+
+2024-06-01 close Assets:Cash

--- a/tests/fuzzing/seeds/beancount/edge-cases.beancount
+++ b/tests/fuzzing/seeds/beancount/edge-cases.beancount
@@ -1,0 +1,95 @@
+; Edge cases for parser fuzzing
+
+; Empty transaction
+2024-01-01 open Assets:A USD
+2024-01-01 open Assets:B USD
+
+; Minimum valid transaction
+2024-01-15 * ""
+  Assets:A  1 USD
+  Assets:B
+
+; Very long narration
+2024-01-15 * "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+  Assets:A  1 USD
+  Assets:B
+
+; Very small amount
+2024-02-01 * "Tiny"
+  Assets:A  0.0001 USD
+  Assets:B
+
+; Very large amount
+2024-02-02 * "Huge"
+  Assets:A  999999999.99 USD
+  Assets:B
+
+; Negative zero
+2024-02-03 * "NegZero"
+  Assets:A  0 USD
+  Assets:B  0 USD
+
+; Many postings
+2024-01-01 open Expenses:A USD
+2024-01-01 open Expenses:B USD
+2024-01-01 open Expenses:C USD
+2024-01-01 open Expenses:D USD
+2024-01-01 open Expenses:E USD
+
+2024-03-01 * "Many postings"
+  Expenses:A  10 USD
+  Expenses:B  20 USD
+  Expenses:C  30 USD
+  Expenses:D  40 USD
+  Expenses:E  50 USD
+  Assets:A   -150 USD
+
+; Deep account hierarchy
+2024-01-01 open Expenses:A:B:C:D:E:F:G:H USD
+2024-04-01 * "Deep"
+  Expenses:A:B:C:D:E:F:G:H  1 USD
+  Assets:A
+
+; Tags and links together
+2024-05-01 * "Tagged" #tag1 #tag2 #tag3 ^link1 ^link2
+  Assets:A  1 USD
+  Assets:B
+
+; Metadata on everything
+2024-06-01 * "Meta"
+  memo: "test"
+  ref: "12345"
+  Assets:A  1 USD
+    lot: "A"
+  Assets:B
+    lot: "B"
+
+; Multiple currencies in one transaction
+2024-01-01 open Assets:EUR EUR
+2024-07-01 * "Multi-currency"
+  Assets:A    100 USD
+  Assets:EUR  85 EUR @ 1.1765 USD
+  Assets:B
+
+; Unicode in payee and narration
+2024-08-01 * "Café Müller" "Frühstück für zwei"
+  Expenses:A  25 USD
+  Assets:A
+
+; Date edge: leap year
+2024-02-29 * "Leap day"
+  Assets:A  1 USD
+  Assets:B
+
+; Date edge: year boundary
+2024-12-31 * "Year end"
+  Assets:A  1 USD
+  Assets:B
+
+; Consecutive semicolons (comments)
+; This is a comment
+;; Double comment
+;;; Triple comment
+
+; Balance at zero
+2024-12-31 balance Assets:B 0 USD

--- a/tests/fuzzing/seeds/beancount/minimal.beancount
+++ b/tests/fuzzing/seeds/beancount/minimal.beancount
@@ -1,0 +1,1 @@
+2024-01-01 open Assets:Bank USD

--- a/tests/fuzzing/seeds/hledger/directives.journal
+++ b/tests/fuzzing/seeds/hledger/directives.journal
@@ -1,0 +1,50 @@
+; hledger seed with all directive types
+
+account assets:bank:checking
+    ; type: Asset
+
+account expenses:food
+
+commodity $1,000.00
+
+decimal-mark .
+
+; Regular transaction
+2024-01-01 * Opening Balance | Opening
+    assets:bank:checking              $10,000.00
+    equity:opening balances
+
+; Pending transaction
+2024-01-15 ! Grocery Store | Weekly shopping
+    ; project: groceries
+    expenses:food                     $85.50
+    assets:bank:checking
+
+; Balance assertion
+2024-02-01 * Balance check
+    assets:bank:checking              $0  = $9,914.50
+
+; Strict balance assertion
+2024-02-15 * Strict check
+    assets:bank:checking              $0  == $9,914.50
+
+; Price declaration
+P 2024-03-01 AAPL $175.00
+P 2024-06-30 EUR $1.07
+
+; Multi-currency transaction
+2024-03-01 * Buy stock
+    assets:brokerage                  10 AAPL @ $175.00
+    assets:bank:checking             $-1,750.00
+
+; Payee directive
+payee Grocery Store
+payee Landlord
+
+; Tag directive
+tag project
+tag trip
+
+; Auto posting rule
+= expenses:food
+    budget:food                       *-1

--- a/tests/fuzzing/seeds/hledger/edge-cases.journal
+++ b/tests/fuzzing/seeds/hledger/edge-cases.journal
@@ -1,0 +1,78 @@
+; Edge cases for hledger parser fuzzing
+
+; Minimal transaction
+2024-01-01
+    assets:a  $1
+    assets:b
+
+; Pipe-separated payee and description
+2024-01-15 * Payee | Description with pipe
+    expenses:food  $50
+    assets:bank
+
+; Secondary date
+2024-02-01=2024-02-05 * Transaction with secondary date
+    expenses:food  $25
+    assets:bank
+
+; Posting comment with tag
+2024-03-01 * Tagged posting
+    expenses:food  $30  ; project: lunch
+    assets:bank
+
+; Transaction comment
+2024-03-15 * Comment on transaction  ; note: important
+    expenses:food  $20
+    assets:bank
+
+; Balance assertion with subaccounts
+2024-04-01 * Check
+    assets:bank  $0 =* $1000
+
+; Very long account name
+2024-05-01 * Deep
+    expenses:a:b:c:d:e:f:g:h  $1
+    assets:bank
+
+; Amount with many decimal places
+2024-06-01 * Precise
+    expenses:food  $0.0001
+    assets:bank
+
+; Negative amounts
+2024-07-01 * Negative
+    assets:bank  $-100
+    income:refund
+
+; Unicode
+2024-08-01 * Café Müller | Frühstück
+    expenses:food  €25
+    assets:bank
+
+; Leap day
+2024-02-29 * Leap
+    assets:a  $1
+    assets:b
+
+; Year boundary
+2024-12-31 * Year end
+    assets:a  $1
+    assets:b
+
+; Multiple currencies
+2024-09-01 * Multi
+    assets:eur  €100 @ $1.07
+    assets:usd
+
+; Empty narration
+2024-10-01 *
+    assets:a  $1
+    assets:b
+
+; Many postings
+2024-11-01 * Many
+    expenses:a  $10
+    expenses:b  $20
+    expenses:c  $30
+    expenses:d  $40
+    assets:bank

--- a/tests/fuzzing/seeds/hledger/minimal.journal
+++ b/tests/fuzzing/seeds/hledger/minimal.journal
@@ -1,0 +1,3 @@
+2024-01-01 Opening
+    assets:bank  $100
+    equity

--- a/tests/fuzzing/seeds/ledger/directives.ledger
+++ b/tests/fuzzing/seeds/ledger/directives.ledger
@@ -1,0 +1,61 @@
+; Ledger seed with all directive types
+
+account Assets:Bank:Checking
+    note My checking account
+    alias checking
+
+account Expenses:Food
+
+commodity $
+    format $1,000.00
+
+commodity AAPL
+    format 1,000.000 AAPL
+
+tag project
+tag trip
+
+year 2024
+
+; Regular transaction
+2024/01/01 * Opening Balance
+    Assets:Bank:Checking                    $10,000.00
+    Equity:Opening Balances
+
+; Pending transaction
+2024/01/15 ! Grocery Store | Weekly shopping
+    ; :groceries:food:
+    Expenses:Food                           $85.50
+    Assets:Bank:Checking
+
+; Transaction with check number
+2024/02/01 * (1234) Landlord | Feb rent
+    Expenses:Housing:Rent                   $1,500.00
+    Assets:Bank:Checking
+
+; Balance assertion
+2024/02/15 * Balance
+    Assets:Bank:Checking                    $0  = $8,414.50
+
+; Periodic transaction
+~ Monthly
+    Expenses:Housing:Rent                   $1,500.00
+    Assets:Bank:Checking
+
+; Automated transaction
+= /Grocery/
+    (Budget:Food)                           -1.0
+
+; Price history
+P 2024/03/01 AAPL $175.00
+P 2024/06/30 AAPL $185.00
+
+; Stock purchase
+2024/03/01 * Buy Stock
+    Assets:Brokerage                        10 AAPL @ $175.00
+    Assets:Bank:Checking                    $-1,750.00
+
+; Effective date
+2024/04/01=2024/04/05 * Future payment
+    Expenses:Insurance                      $200.00
+    Assets:Bank:Checking

--- a/tests/fuzzing/seeds/ledger/edge-cases.ledger
+++ b/tests/fuzzing/seeds/ledger/edge-cases.ledger
@@ -1,0 +1,69 @@
+; Edge cases for Ledger parser fuzzing
+
+; Empty description
+2024/01/01 *
+    Assets:Bank                             $100.00
+    Equity
+
+; Virtual postings
+2024/01/15 * Test
+    Expenses:Food                           $50.00
+    (Budget:Food)                           $-50.00
+    Assets:Bank
+
+; Balanced virtual postings
+2024/01/20 * Test
+    Expenses:Food                           $50.00
+    [Budget:Food]                           $-50.00
+    Assets:Bank
+
+; Value expression in amount
+2024/02/01 * Expression
+    Expenses:Food                           ($10 * 5)
+    Assets:Bank
+
+; Lot with date
+2024/03/01 * Buy
+    Assets:Brokerage                        10 AAPL {$175.00} [2024/03/01]
+    Assets:Bank
+
+; Total cost
+2024/03/15 * Buy total cost
+    Assets:Brokerage                        10 AAPL @@ $1,800.00
+    Assets:Bank
+
+; Multi-line metadata
+2024/04/01 * Metadata test
+    ; key: value
+    ; :tag1:tag2:tag3:
+    Expenses:Food                           $25.00
+    Assets:Bank
+
+; Spaces in account names
+2024/05/01 * Spaces
+    Expenses:Auto:Gas & Oil                 $45.00
+    Assets:Bank
+
+; Very long payee
+2024/06/01 * AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA | BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+    Expenses:Food                           $1.00
+    Assets:Bank
+
+; Negative amount with commodity on left
+2024/07/01 * Negative
+    Assets:Bank                             $-100.00
+    Income:Refund
+
+; Zero amount
+2024/08/01 * Zero
+    Assets:Bank                             $0.00
+    Expenses:Test                           $0.00
+
+; Date formats
+2024/02/29 * Leap day
+    Assets:Bank                             $1.00
+    Equity
+
+2024/12/31 * Year end
+    Assets:Bank                             $1.00
+    Equity

--- a/tests/fuzzing/seeds/ledger/minimal.ledger
+++ b/tests/fuzzing/seeds/ledger/minimal.ledger
@@ -1,0 +1,3 @@
+2024/01/01 Opening
+    Assets:Bank  $100
+    Equity


### PR DESCRIPTION
## Summary

Adds 10 fuzzing seed files matching the structure documented in the fuzzing README:

| Format | Files |
|---|---|
| Beancount | minimal, directives, complex, edge-cases |
| Ledger | minimal, directives, edge-cases |
| hledger | minimal, directives, edge-cases |

Seeds cover: all directive types, cost basis, multi-currency, virtual postings, value expressions, balance assertions, unicode, deep account hierarchies, boundary dates, metadata, tags/links, and various amount edge cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)