### PR TITLE
fix: classify booking/interpolation errors as validation, not parse

### DIFF
--- a/tests/harness/runners/python/executors/validation.py
+++ b/tests/harness/runners/python/executors/validation.py
@@ -43,20 +43,28 @@ class ValidationExecutor(BaseExecutor):
 
             # Separate parse errors from validation errors
             # In beancount, loader.load_file returns all errors combined.
-            # Parse errors come from the parser module; validation errors from elsewhere.
+            # Parse errors come from the parser/lexer; booking, interpolation,
+            # categorization, and reduction errors are validation-phase.
+            VALIDATION_ERROR_NAMES = {
+                "CategorizationError",
+                "AmbiguousMatchError",
+                "ReductionError",
+                "InterpolationError",
+                "BookingError",
+                "ValidationError",
+            }
+
             def is_parse_error(e: object) -> bool:
-                mod = type(e).__module__ or ""
                 name = type(e).__name__
-                return (
-                    "parser" in mod.lower()
-                    or "lexer" in mod.lower()
-                    or name
-                    in {
-                        "ParserError",
-                        "ParserSyntaxError",
-                        "LexerError",
-                    }
-                )
+                # Booking/interpolation/validation errors are never parse errors,
+                # even if their module path contains "parser"
+                if name in VALIDATION_ERROR_NAMES:
+                    return False
+                return name in {
+                    "ParserError",
+                    "ParserSyntaxError",
+                    "LexerError",
+                }
 
             parse_errors = [e for e in errors if is_parse_error(e)]
             validation_errors = [e for e in errors if not is_parse_error(e)]


### PR DESCRIPTION
## Summary

The `is_parse_error()` function in validation.py used `"parser" in module_path` which was too broad — beancount's `InterpolationError`, `CategorizationError`, `AmbiguousMatchError`, and `ReductionError` live under `beancount.parser.*` modules despite being validation-phase errors.

This caused 6 conformance tests to fail with "Expected parse=success, got error" because booking errors were misclassified as parse errors.

**Fix**: Use explicit class name matching. Known validation error types are excluded first, then only `ParserError`/`ParserSyntaxError`/`LexerError` count as parse errors.

## Test plan

- [ ] Beancount conformance back to 264/0
- [ ] Rustledger conformance unchanged at 204/60

🤖 Generated with [Claude Code](https://claude.com/claude-code)