### PR TITLE
fix: include rustledger commit SHA in cargo cache key

### DIFF
--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -118,11 +118,16 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Get rustledger commit SHA
+        id: rl-sha
+        run: echo "sha=$(cd rustledger && git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: rustledger
           cache-on-failure: true
+          key: rl-${{ steps.rl-sha.outputs.sha }}
 
       - name: Build rustledger
         run: |


### PR DESCRIPTION
## Summary

The rust-cache was keyed only on `Cargo.lock`, so when rustledger source files changed but dependencies didn't, stale compiled artifacts were restored from cache. This caused conformance tests to run against an old build despite checking out the latest rustledger main.

This explains why 5 parser fixes and BQL function fixes appeared "not working" — the fixes were on main but we were testing a cached old binary.

**Fix**: Add the rustledger HEAD SHA to the cache key so any source change triggers a fresh build.

## Test plan

- [ ] Rustledger conformance improves (stale cache was hiding fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)