### PR TITLE
fix: ensure test IDs are unique within each manifest scope

### DIFF
--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -292,3 +292,6 @@ jobs:
           else:
               print(f'Validated {len(test_files)} test files successfully')
           "
+
+      - name: Check test IDs are unique within each manifest
+        run: python scripts/check_test_ids_unique.py

--- a/scripts/check_test_ids_unique.py
+++ b/scripts/check_test_ids_unique.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Validate that test IDs are unique within each test manifest's scope.
+
+Loads each manifest.json, iterates its test_directories, and verifies
+that no test ID appears in more than one directory within the same
+manifest. Exits non-zero if duplicates are found.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+def find_duplicates(manifest_path: Path) -> dict[str, list[str]]:
+    """Return {test_id: [directories]} for any ID that appears in more than one directory."""
+    manifest = json.loads(manifest_path.read_text())
+    base = manifest_path.parent
+    id_dirs: dict[str, list[str]] = defaultdict(list)
+    for directory in manifest.get("test_directories", []):
+        tests_file = base / directory / "tests.json"
+        if not tests_file.exists():
+            continue
+        data = json.loads(tests_file.read_text())
+        for test in data.get("tests", []):
+            id_dirs[test["id"]].append(directory)
+    return {tid: dirs for tid, dirs in id_dirs.items() if len(dirs) > 1}
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    manifests = sorted((repo_root / "tests").rglob("manifest.json"))
+    if not manifests:
+        print("No manifest.json files found under tests/", file=sys.stderr)
+        return 1
+
+    total_dupes = 0
+    for manifest_path in manifests:
+        rel = manifest_path.relative_to(repo_root)
+        dupes = find_duplicates(manifest_path)
+        if dupes:
+            print(f"{rel}: {len(dupes)} duplicate test ID(s)")
+            for tid, dirs in sorted(dupes.items()):
+                print(f"  {tid}: {dirs}")
+            total_dupes += len(dupes)
+        else:
+            print(f"{rel}: OK")
+
+    if total_dupes > 0:
+        print(f"\nFound {total_dupes} duplicate test ID(s) total", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/beancount/v3/booking/tests.json
+++ b/tests/beancount/v3/booking/tests.json
@@ -7,68 +7,101 @@
       "id": "booking-strict-exact-match",
       "description": "STRICT booking with exact cost match succeeds",
       "spec_ref": "booking.md#strict-booking",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL \"STRICT\"\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-02-15 * \"Sell\"\n  Assets:Stock -5 AAPL {150 USD}\n  Assets:Cash 800 USD\n  Income:Gains"},
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL \"STRICT\"\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-02-15 * \"Sell\"\n  Assets:Stock -5 AAPL {150 USD}\n  Assets:Cash 800 USD\n  Income:Gains"
+      },
       "expected": {
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["booking", "strict"]
+      "tags": [
+        "booking",
+        "strict"
+      ]
     },
     {
       "id": "booking-strict-ambiguous",
       "description": "STRICT booking with ambiguous reduction produces error",
       "spec_ref": "booking.md#strict-booking",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL \"STRICT\"\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy lot 1\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-01-20 * \"Buy lot 2\"\n  Assets:Stock 10 AAPL {160 USD}\n  Assets:Cash -1600 USD\n\n2024-02-15 * \"Sell - ambiguous\"\n  Assets:Stock -5 AAPL {}\n  Assets:Cash 800 USD\n  Income:Gains"},
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL \"STRICT\"\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy lot 1\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-01-20 * \"Buy lot 2\"\n  Assets:Stock 10 AAPL {160 USD}\n  Assets:Cash -1600 USD\n\n2024-02-15 * \"Sell - ambiguous\"\n  Assets:Stock -5 AAPL {}\n  Assets:Cash 800 USD\n  Income:Gains"
+      },
       "expected": {
         "parse": "success",
         "validate": "error",
-        "error_contains": ["ambiguous"]
+        "error_contains": [
+          "ambiguous"
+        ]
       },
-      "tags": ["booking", "strict", "ambiguous"]
+      "tags": [
+        "booking",
+        "strict",
+        "ambiguous"
+      ]
     },
     {
       "id": "booking-fifo-order",
       "description": "FIFO booking sells oldest lots first",
       "spec_ref": "booking.md#fifo-booking",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL \"FIFO\"\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy lot 1 at 150\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-01-20 * \"Buy lot 2 at 160\"\n  Assets:Stock 10 AAPL {160 USD}\n  Assets:Cash -1600 USD\n\n2024-02-15 * \"Sell 5 - should match lot 1\"\n  Assets:Stock -5 AAPL {}\n  Assets:Cash 800 USD\n  Income:Gains"},
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL \"FIFO\"\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy lot 1 at 150\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-01-20 * \"Buy lot 2 at 160\"\n  Assets:Stock 10 AAPL {160 USD}\n  Assets:Cash -1600 USD\n\n2024-02-15 * \"Sell 5 - should match lot 1\"\n  Assets:Stock -5 AAPL {}\n  Assets:Cash 800 USD\n  Income:Gains"
+      },
       "expected": {
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["booking", "fifo"]
+      "tags": [
+        "booking",
+        "fifo"
+      ]
     },
     {
       "id": "booking-lifo-order",
       "description": "LIFO booking sells newest lots first",
       "spec_ref": "booking.md#lifo-booking",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL \"LIFO\"\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy lot 1 at 150\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-01-20 * \"Buy lot 2 at 160\"\n  Assets:Stock 10 AAPL {160 USD}\n  Assets:Cash -1600 USD\n\n2024-02-15 * \"Sell 5 - should match lot 2\"\n  Assets:Stock -5 AAPL {}\n  Assets:Cash 800 USD\n  Income:Gains"},
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL \"LIFO\"\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy lot 1 at 150\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-01-20 * \"Buy lot 2 at 160\"\n  Assets:Stock 10 AAPL {160 USD}\n  Assets:Cash -1600 USD\n\n2024-02-15 * \"Sell 5 - should match lot 2\"\n  Assets:Stock -5 AAPL {}\n  Assets:Cash 800 USD\n  Income:Gains"
+      },
       "expected": {
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["booking", "lifo"]
+      "tags": [
+        "booking",
+        "lifo"
+      ]
     },
     {
       "id": "booking-hifo-order",
       "description": "HIFO booking sells highest cost lots first",
       "spec_ref": "booking.md#hifo-booking",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL \"HIFO\"\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy lot 1 at 150\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-01-20 * \"Buy lot 2 at 160\"\n  Assets:Stock 10 AAPL {160 USD}\n  Assets:Cash -1600 USD\n\n2024-01-25 * \"Buy lot 3 at 155\"\n  Assets:Stock 10 AAPL {155 USD}\n  Assets:Cash -1550 USD\n\n2024-02-15 * \"Sell 5 - should match lot 2 (highest)\"\n  Assets:Stock -5 AAPL {}\n  Assets:Cash 800 USD\n  Income:Gains"},
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL \"HIFO\"\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy lot 1 at 150\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-01-20 * \"Buy lot 2 at 160\"\n  Assets:Stock 10 AAPL {160 USD}\n  Assets:Cash -1600 USD\n\n2024-01-25 * \"Buy lot 3 at 155\"\n  Assets:Stock 10 AAPL {155 USD}\n  Assets:Cash -1550 USD\n\n2024-02-15 * \"Sell 5 - should match lot 2 (highest)\"\n  Assets:Stock -5 AAPL {}\n  Assets:Cash 800 USD\n  Income:Gains"
+      },
       "expected": {
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["booking", "hifo"]
+      "tags": [
+        "booking",
+        "hifo"
+      ]
     },
     {
       "id": "booking-none-new-lot",
       "description": "NONE booking always creates new lot",
       "spec_ref": "booking.md#none-booking",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL \"NONE\"\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy at 150\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-02-15 * \"Sell with new lot\"\n  Assets:Stock -5 AAPL {155 USD}\n  Assets:Cash 775 USD\n  Income:Gains"},
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL \"NONE\"\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy at 150\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-02-15 * \"Sell with new lot\"\n  Assets:Stock -5 AAPL {155 USD}\n  Assets:Cash 775 USD\n  Income:Gains"
+      },
       "expected": {
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["booking", "none"]
+      "tags": [
+        "booking",
+        "none"
+      ]
     },
     {
       "id": "booking-average-cost",
@@ -76,101 +109,152 @@
       "spec_ref": "booking.md#average-cost",
       "skip": true,
       "skip_reason": "AVERAGE booking method not implemented in Python beancount 3.x",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL \"AVERAGE\"\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy lot 1 at 100\"\n  Assets:Stock 10 AAPL {100 USD}\n  Assets:Cash -1000 USD\n\n2024-01-20 * \"Buy lot 2 at 200\"\n  Assets:Stock 10 AAPL {200 USD}\n  Assets:Cash -2000 USD\n\n2024-02-15 * \"Sell at average (150)\"\n  Assets:Stock -5 AAPL {}\n  Assets:Cash 800 USD\n  Income:Gains"},
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL \"AVERAGE\"\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy lot 1 at 100\"\n  Assets:Stock 10 AAPL {100 USD}\n  Assets:Cash -1000 USD\n\n2024-01-20 * \"Buy lot 2 at 200\"\n  Assets:Stock 10 AAPL {200 USD}\n  Assets:Cash -2000 USD\n\n2024-02-15 * \"Sell at average (150)\"\n  Assets:Stock -5 AAPL {}\n  Assets:Cash 800 USD\n  Income:Gains"
+      },
       "expected": {
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["booking", "average", "unimplemented"]
+      "tags": [
+        "booking",
+        "average",
+        "unimplemented"
+      ]
     },
     {
       "id": "booking-default-strict",
       "description": "Default booking method is STRICT when no method specified",
       "spec_ref": "booking.md#default-booking",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-01-20 * \"Buy different cost\"\n  Assets:Stock 10 AAPL {160 USD}\n  Assets:Cash -1600 USD\n\n2024-02-15 * \"Sell - ambiguous without booking method\"\n  Assets:Stock -5 AAPL {}\n  Assets:Cash 800 USD\n  Income:Gains"},
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-01-20 * \"Buy different cost\"\n  Assets:Stock 10 AAPL {160 USD}\n  Assets:Cash -1600 USD\n\n2024-02-15 * \"Sell - ambiguous without booking method\"\n  Assets:Stock -5 AAPL {}\n  Assets:Cash 800 USD\n  Income:Gains"
+      },
       "expected": {
         "parse": "success",
         "validate": "error",
-        "error_contains": ["ambiguous"]
+        "error_contains": [
+          "ambiguous"
+        ]
       },
-      "tags": ["booking", "default"]
+      "tags": [
+        "booking",
+        "default"
+      ]
     },
     {
-      "id": "cost-per-unit",
+      "id": "cost-per-unit-booking",
       "description": "Cost specified as per-unit price",
       "spec_ref": "costs.md#per-unit-cost",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Assets:Cash USD\n\n2024-01-15 * \"Buy\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD"},
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Assets:Cash USD\n\n2024-01-15 * \"Buy\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD"
+      },
       "expected": {
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["cost", "per-unit"]
+      "tags": [
+        "cost",
+        "per-unit"
+      ]
     },
     {
-      "id": "cost-total",
+      "id": "cost-total-booking",
       "description": "Cost specified as total amount",
       "spec_ref": "costs.md#total-cost",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Assets:Cash USD\n\n2024-01-15 * \"Buy\"\n  Assets:Stock 10 AAPL {{1500 USD}}\n  Assets:Cash -1500 USD"},
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Assets:Cash USD\n\n2024-01-15 * \"Buy\"\n  Assets:Stock 10 AAPL {{1500 USD}}\n  Assets:Cash -1500 USD"
+      },
       "expected": {
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["cost", "total"]
+      "tags": [
+        "cost",
+        "total"
+      ]
     },
     {
-      "id": "cost-with-date",
+      "id": "cost-with-date-booking",
       "description": "Cost specification with acquisition date",
       "spec_ref": "costs.md#cost-date",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Assets:Cash USD\n\n2024-01-15 * \"Buy\"\n  Assets:Stock 10 AAPL {150 USD, 2024-01-15}\n  Assets:Cash -1500 USD"},
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Assets:Cash USD\n\n2024-01-15 * \"Buy\"\n  Assets:Stock 10 AAPL {150 USD, 2024-01-15}\n  Assets:Cash -1500 USD"
+      },
       "expected": {
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["cost", "date"]
+      "tags": [
+        "cost",
+        "date"
+      ]
     },
     {
-      "id": "cost-with-label",
+      "id": "cost-with-label-booking",
       "description": "Cost specification with lot label",
       "spec_ref": "costs.md#lot-label",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Assets:Cash USD\n\n2024-01-15 * \"Buy\"\n  Assets:Stock 10 AAPL {150 USD, \"lot1\"}\n  Assets:Cash -1500 USD"},
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Assets:Cash USD\n\n2024-01-15 * \"Buy\"\n  Assets:Stock 10 AAPL {150 USD, \"lot1\"}\n  Assets:Cash -1500 USD"
+      },
       "expected": {
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["cost", "label"]
+      "tags": [
+        "cost",
+        "label"
+      ]
     },
     {
       "id": "cost-match-by-label",
       "description": "Match lot by label in STRICT booking",
       "spec_ref": "booking.md#lot-matching",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL \"STRICT\"\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy lot 1\"\n  Assets:Stock 10 AAPL {150 USD, \"lot1\"}\n  Assets:Cash -1500 USD\n\n2024-01-20 * \"Buy lot 2\"\n  Assets:Stock 10 AAPL {160 USD, \"lot2\"}\n  Assets:Cash -1600 USD\n\n2024-02-15 * \"Sell from lot 1 by label\"\n  Assets:Stock -5 AAPL {150 USD, \"lot1\"}\n  Assets:Cash 800 USD\n  Income:Gains"},
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL \"STRICT\"\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy lot 1\"\n  Assets:Stock 10 AAPL {150 USD, \"lot1\"}\n  Assets:Cash -1500 USD\n\n2024-01-20 * \"Buy lot 2\"\n  Assets:Stock 10 AAPL {160 USD, \"lot2\"}\n  Assets:Cash -1600 USD\n\n2024-02-15 * \"Sell from lot 1 by label\"\n  Assets:Stock -5 AAPL {150 USD, \"lot1\"}\n  Assets:Cash 800 USD\n  Income:Gains"
+      },
       "expected": {
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["booking", "label", "strict"]
+      "tags": [
+        "booking",
+        "label",
+        "strict"
+      ]
     },
     {
       "id": "cost-match-by-date",
       "description": "Match lot by acquisition date in STRICT booking",
       "spec_ref": "booking.md#lot-matching",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL \"STRICT\"\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy lot 1\"\n  Assets:Stock 10 AAPL {150 USD, 2024-01-15}\n  Assets:Cash -1500 USD\n\n2024-01-20 * \"Buy lot 2\"\n  Assets:Stock 10 AAPL {150 USD, 2024-01-20}\n  Assets:Cash -1500 USD\n\n2024-02-15 * \"Sell from lot 1 by date\"\n  Assets:Stock -5 AAPL {150 USD, 2024-01-15}\n  Assets:Cash 800 USD\n  Income:Gains"},
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL \"STRICT\"\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy lot 1\"\n  Assets:Stock 10 AAPL {150 USD, 2024-01-15}\n  Assets:Cash -1500 USD\n\n2024-01-20 * \"Buy lot 2\"\n  Assets:Stock 10 AAPL {150 USD, 2024-01-20}\n  Assets:Cash -1500 USD\n\n2024-02-15 * \"Sell from lot 1 by date\"\n  Assets:Stock -5 AAPL {150 USD, 2024-01-15}\n  Assets:Cash 800 USD\n  Income:Gains"
+      },
       "expected": {
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["booking", "date", "strict"]
+      "tags": [
+        "booking",
+        "date",
+        "strict"
+      ]
     },
     {
       "id": "cost-empty-spec",
       "description": "Empty cost spec {} uses automatic matching",
       "spec_ref": "costs.md#empty-cost",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL \"FIFO\"\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-02-15 * \"Sell with empty spec\"\n  Assets:Stock -5 AAPL {}\n  Assets:Cash 800 USD\n  Income:Gains"},
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL \"FIFO\"\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-02-15 * \"Sell with empty spec\"\n  Assets:Stock -5 AAPL {}\n  Assets:Cash 800 USD\n  Income:Gains"
+      },
       "expected": {
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["cost", "empty", "fifo"]
+      "tags": [
+        "cost",
+        "empty",
+        "fifo"
+      ]
     },
     {
       "id": "cost-asterisk-merge",
@@ -178,135 +262,206 @@
       "spec_ref": "costs.md#cost-merge",
       "skip": true,
       "skip_reason": "Cost merging {*} not implemented in Python beancount 3.x",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy lot 1\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-01-20 * \"Buy lot 2\"\n  Assets:Stock 10 AAPL {160 USD}\n  Assets:Cash -1600 USD\n\n2024-02-15 * \"Sell with merge\"\n  Assets:Stock -5 AAPL {*}\n  Assets:Cash 800 USD\n  Income:Gains"},
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy lot 1\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-01-20 * \"Buy lot 2\"\n  Assets:Stock 10 AAPL {160 USD}\n  Assets:Cash -1600 USD\n\n2024-02-15 * \"Sell with merge\"\n  Assets:Stock -5 AAPL {*}\n  Assets:Cash 800 USD\n  Income:Gains"
+      },
       "expected": {
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["cost", "merge", "unimplemented"]
+      "tags": [
+        "cost",
+        "merge",
+        "unimplemented"
+      ]
     },
     {
       "id": "reduction-exceeds-inventory",
       "description": "Reduction exceeding inventory produces error",
       "spec_ref": "booking.md#reduction-validation",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL \"FIFO\"\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-02-15 * \"Sell more than owned\"\n  Assets:Stock -15 AAPL {}\n  Assets:Cash 2250 USD\n  Income:Gains"},
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL \"FIFO\"\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-02-15 * \"Sell more than owned\"\n  Assets:Stock -15 AAPL {}\n  Assets:Cash 2250 USD\n  Income:Gains"
+      },
       "expected": {
         "parse": "success",
         "validate": "error",
-        "error_contains": ["not enough"]
+        "error_contains": [
+          "not enough"
+        ]
       },
-      "tags": ["booking", "reduction", "error"]
+      "tags": [
+        "booking",
+        "reduction",
+        "error"
+      ]
     },
     {
       "id": "reduction-no-matching-lot",
       "description": "Reduction with no matching lot produces error",
       "spec_ref": "booking.md#lot-matching",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL \"STRICT\"\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-02-15 * \"Sell at wrong cost\"\n  Assets:Stock -5 AAPL {200 USD}\n  Assets:Cash 1000 USD\n  Income:Gains"},
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL \"STRICT\"\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-02-15 * \"Sell at wrong cost\"\n  Assets:Stock -5 AAPL {200 USD}\n  Assets:Cash 1000 USD\n  Income:Gains"
+      },
       "expected": {
         "parse": "success",
         "validate": "error"
       },
-      "tags": ["booking", "strict", "error"]
+      "tags": [
+        "booking",
+        "strict",
+        "error"
+      ]
     },
     {
       "id": "booking-method-case-sensitive",
       "description": "Booking method must be uppercase",
       "spec_ref": "booking.md#booking-method-syntax",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL \"fifo\""},
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL \"fifo\""
+      },
       "expected": {
         "parse": "error",
-        "error_contains": ["Invalid booking method"]
+        "error_contains": [
+          "Invalid booking method"
+        ]
       },
-      "tags": ["booking", "syntax"]
+      "tags": [
+        "booking",
+        "syntax"
+      ]
     },
     {
       "id": "cost-no-currency",
       "description": "Cost without explicit currency infers from transaction",
       "spec_ref": "costs.md#cost-syntax",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Assets:Cash USD\n\n2024-01-15 * \"Buy\"\n  Assets:Stock 10 AAPL {150}\n  Assets:Cash -1500 USD"},
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Assets:Cash USD\n\n2024-01-15 * \"Buy\"\n  Assets:Stock 10 AAPL {150}\n  Assets:Cash -1500 USD"
+      },
       "expected": {
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["cost", "syntax"]
+      "tags": [
+        "cost",
+        "syntax"
+      ]
     },
     {
-      "id": "price-annotation",
+      "id": "price-annotation-booking",
       "description": "Price annotation @ for market value",
       "spec_ref": "costs.md#price-annotation",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-02-15 * \"Sell with price\"\n  Assets:Stock -10 AAPL {150 USD} @ 175 USD\n  Assets:Cash 1750 USD\n  Income:Gains -250 USD"},
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-02-15 * \"Sell with price\"\n  Assets:Stock -10 AAPL {150 USD} @ 175 USD\n  Assets:Cash 1750 USD\n  Income:Gains -250 USD"
+      },
       "expected": {
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["cost", "price"]
+      "tags": [
+        "cost",
+        "price"
+      ]
     },
     {
-      "id": "price-total-annotation",
+      "id": "price-total-annotation-booking",
       "description": "Total price annotation @@ for market value",
       "spec_ref": "costs.md#total-price",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-02-15 * \"Sell with total price\"\n  Assets:Stock -10 AAPL {150 USD} @@ 1750 USD\n  Assets:Cash 1750 USD\n  Income:Gains -250 USD"},
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-02-15 * \"Sell with total price\"\n  Assets:Stock -10 AAPL {150 USD} @@ 1750 USD\n  Assets:Cash 1750 USD\n  Income:Gains -250 USD"
+      },
       "expected": {
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["cost", "price", "total"]
+      "tags": [
+        "cost",
+        "price",
+        "total"
+      ]
     },
     {
       "id": "augmentation-same-lot",
       "description": "Augmentation with matching cost adds to existing lot",
       "spec_ref": "booking.md#augmentation",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Assets:Cash USD\n\n2024-01-15 * \"Buy first\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-01-20 * \"Buy more at same cost\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD"},
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Assets:Cash USD\n\n2024-01-15 * \"Buy first\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-01-20 * \"Buy more at same cost\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD"
+      },
       "expected": {
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["booking", "augmentation"]
+      "tags": [
+        "booking",
+        "augmentation"
+      ]
     },
     {
       "id": "augmentation-new-lot",
       "description": "Augmentation with different cost creates new lot",
       "spec_ref": "booking.md#augmentation",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Assets:Cash USD\n\n2024-01-15 * \"Buy first\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-01-20 * \"Buy at different cost\"\n  Assets:Stock 10 AAPL {160 USD}\n  Assets:Cash -1600 USD"},
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Assets:Cash USD\n\n2024-01-15 * \"Buy first\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-01-20 * \"Buy at different cost\"\n  Assets:Stock 10 AAPL {160 USD}\n  Assets:Cash -1600 USD"
+      },
       "expected": {
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["booking", "augmentation"]
+      "tags": [
+        "booking",
+        "augmentation"
+      ]
     },
     {
       "id": "multi-commodity-inventory",
       "description": "Account can hold multiple commodities",
       "spec_ref": "booking.md#inventory",
-      "input": {"inline": "2024-01-01 open Assets:Portfolio AAPL,GOOGL\n2024-01-01 open Assets:Cash USD\n\n2024-01-15 * \"Buy AAPL\"\n  Assets:Portfolio 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-01-20 * \"Buy GOOGL\"\n  Assets:Portfolio 5 GOOGL {140 USD}\n  Assets:Cash -700 USD"},
+      "input": {
+        "inline": "2024-01-01 open Assets:Portfolio AAPL,GOOGL\n2024-01-01 open Assets:Cash USD\n\n2024-01-15 * \"Buy AAPL\"\n  Assets:Portfolio 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-01-20 * \"Buy GOOGL\"\n  Assets:Portfolio 5 GOOGL {140 USD}\n  Assets:Cash -700 USD"
+      },
       "expected": {
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["booking", "inventory", "multi-commodity"]
+      "tags": [
+        "booking",
+        "inventory",
+        "multi-commodity"
+      ]
     },
     {
       "id": "negative-cost-error",
       "description": "Negative cost produces error",
       "spec_ref": "costs.md#cost-validation",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Assets:Cash USD\n\n2024-01-15 * \"Buy\"\n  Assets:Stock 10 AAPL {-150 USD}\n  Assets:Cash 1500 USD"},
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Assets:Cash USD\n\n2024-01-15 * \"Buy\"\n  Assets:Stock 10 AAPL {-150 USD}\n  Assets:Cash 1500 USD"
+      },
       "expected": {
         "parse": "success",
         "validate": "error",
-        "error_contains": ["Cost is negative"]
+        "error_contains": [
+          "Cost is negative"
+        ]
       },
-      "tags": ["cost", "validation"]
+      "tags": [
+        "cost",
+        "validation"
+      ]
     },
     {
       "id": "zero-cost-valid",
       "description": "Zero cost is valid",
       "spec_ref": "costs.md#zero-cost",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Equity:Opening\n\n2024-01-15 * \"Grant\"\n  Assets:Stock 100 AAPL {0 USD}\n  Equity:Opening"},
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Equity:Opening\n\n2024-01-15 * \"Grant\"\n  Assets:Stock 100 AAPL {0 USD}\n  Equity:Opening"
+      },
       "expected": {
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["cost", "zero"]
+      "tags": [
+        "cost",
+        "zero"
+      ]
     }
   ]
 }

--- a/tests/beancount/v3/regression/tests.json
+++ b/tests/beancount/v3/regression/tests.json
@@ -4,7 +4,7 @@
   "description": "Regression tests for fixed bugs and edge cases",
   "tests": [
     {
-      "id": "unicode-account-name",
+      "id": "unicode-account-name-regression",
       "description": "Account with Unicode characters after ASCII start",
       "spec_ref": "lexical.md#account",
       "input": {
@@ -14,10 +14,13 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["unicode", "accounts"]
+      "tags": [
+        "unicode",
+        "accounts"
+      ]
     },
     {
-      "id": "unicode-narration",
+      "id": "unicode-narration-regression",
       "description": "Transaction with Unicode narration including emoji",
       "spec_ref": "lexical.md#string",
       "input": {
@@ -27,10 +30,13 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["unicode", "strings"]
+      "tags": [
+        "unicode",
+        "strings"
+      ]
     },
     {
-      "id": "leap-year-date",
+      "id": "leap-year-date-regression",
       "description": "Transaction on Feb 29 in leap year",
       "spec_ref": "lexical.md#date",
       "input": {
@@ -40,7 +46,10 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["date", "edge-case"]
+      "tags": [
+        "date",
+        "edge-case"
+      ]
     },
     {
       "id": "invalid-leap-year-date",
@@ -51,9 +60,15 @@
       },
       "expected": {
         "parse": "error",
-        "error_contains": ["day", "out of range"]
+        "error_contains": [
+          "day",
+          "out of range"
+        ]
       },
-      "tags": ["date", "error"]
+      "tags": [
+        "date",
+        "error"
+      ]
     },
     {
       "id": "year-boundary-transaction",
@@ -66,10 +81,13 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["date", "edge-case"]
+      "tags": [
+        "date",
+        "edge-case"
+      ]
     },
     {
-      "id": "very-large-amount",
+      "id": "very-large-amount-regression",
       "description": "Transaction with very large amount",
       "spec_ref": "amounts.md",
       "input": {
@@ -79,10 +97,13 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["numbers", "edge-case"]
+      "tags": [
+        "numbers",
+        "edge-case"
+      ]
     },
     {
-      "id": "very-small-amount",
+      "id": "very-small-amount-regression",
       "description": "Transaction with very small amount",
       "spec_ref": "amounts.md",
       "input": {
@@ -92,7 +113,10 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["numbers", "edge-case"]
+      "tags": [
+        "numbers",
+        "edge-case"
+      ]
     },
     {
       "id": "number-with-grouping",
@@ -105,7 +129,9 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["numbers"]
+      "tags": [
+        "numbers"
+      ]
     },
     {
       "id": "multiline-narration",
@@ -118,7 +144,10 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["strings", "multiline"]
+      "tags": [
+        "strings",
+        "multiline"
+      ]
     },
     {
       "id": "escaped-quotes-in-string",
@@ -131,7 +160,10 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["strings", "escape"]
+      "tags": [
+        "strings",
+        "escape"
+      ]
     },
     {
       "id": "escaped-backslash-in-string",
@@ -144,7 +176,10 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["strings", "escape"]
+      "tags": [
+        "strings",
+        "escape"
+      ]
     },
     {
       "id": "long-account-chain",
@@ -157,7 +192,9 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["accounts"]
+      "tags": [
+        "accounts"
+      ]
     },
     {
       "id": "account-with-numbers",
@@ -170,7 +207,9 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["accounts"]
+      "tags": [
+        "accounts"
+      ]
     },
     {
       "id": "currency-with-special-chars",
@@ -183,7 +222,9 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["currency"]
+      "tags": [
+        "currency"
+      ]
     },
     {
       "id": "multiple-currencies-transaction",
@@ -196,7 +237,10 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["currency", "price"]
+      "tags": [
+        "currency",
+        "price"
+      ]
     },
     {
       "id": "balance-with-multiple-commodities",
@@ -209,7 +253,10 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["balance", "multi-commodity"]
+      "tags": [
+        "balance",
+        "multi-commodity"
+      ]
     },
     {
       "id": "cost-with-date-and-label",
@@ -222,7 +269,10 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["costs", "lot"]
+      "tags": [
+        "costs",
+        "lot"
+      ]
     },
     {
       "id": "total-cost-specification",
@@ -235,7 +285,10 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["costs", "total"]
+      "tags": [
+        "costs",
+        "total"
+      ]
     },
     {
       "id": "total-price-specification",
@@ -248,7 +301,10 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["price", "total"]
+      "tags": [
+        "price",
+        "total"
+      ]
     },
     {
       "id": "transaction-with-all-flags",
@@ -261,7 +317,10 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["transaction", "flags"]
+      "tags": [
+        "transaction",
+        "flags"
+      ]
     },
     {
       "id": "posting-with-flag",
@@ -274,7 +333,10 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["posting", "flags"]
+      "tags": [
+        "posting",
+        "flags"
+      ]
     },
     {
       "id": "metadata-all-types",
@@ -287,7 +349,9 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["metadata"]
+      "tags": [
+        "metadata"
+      ]
     },
     {
       "id": "posting-metadata",
@@ -300,10 +364,13 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["metadata", "posting"]
+      "tags": [
+        "metadata",
+        "posting"
+      ]
     },
     {
-      "id": "pushtag-poptag",
+      "id": "pushtag-poptag-regression",
       "description": "Push and pop tag directives",
       "spec_ref": "tags-links.md#pushtag",
       "input": {
@@ -313,10 +380,13 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["tags", "push-pop"]
+      "tags": [
+        "tags",
+        "push-pop"
+      ]
     },
     {
-      "id": "pushmeta-popmeta",
+      "id": "pushmeta-popmeta-regression",
       "description": "Push and pop metadata directives",
       "spec_ref": "metadata.md#pushmeta",
       "input": {
@@ -326,10 +396,13 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["metadata", "push-pop"]
+      "tags": [
+        "metadata",
+        "push-pop"
+      ]
     },
     {
-      "id": "pad-directive",
+      "id": "pad-directive-regression",
       "description": "Pad directive with balance",
       "spec_ref": "directives/pad.md",
       "input": {
@@ -339,10 +412,12 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["pad"]
+      "tags": [
+        "pad"
+      ]
     },
     {
-      "id": "event-directive",
+      "id": "event-directive-regression",
       "description": "Event directive",
       "spec_ref": "directives/event.md",
       "input": {
@@ -352,10 +427,12 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["event"]
+      "tags": [
+        "event"
+      ]
     },
     {
-      "id": "query-directive",
+      "id": "query-directive-regression",
       "description": "Query directive",
       "spec_ref": "directives/query.md",
       "input": {
@@ -365,10 +442,12 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["query"]
+      "tags": [
+        "query"
+      ]
     },
     {
-      "id": "note-directive",
+      "id": "note-directive-regression",
       "description": "Note directive",
       "spec_ref": "directives/note.md",
       "input": {
@@ -378,10 +457,12 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["note"]
+      "tags": [
+        "note"
+      ]
     },
     {
-      "id": "custom-directive",
+      "id": "custom-directive-regression",
       "description": "Custom directive with various values",
       "spec_ref": "directives/custom.md",
       "input": {
@@ -391,7 +472,9 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["custom"]
+      "tags": [
+        "custom"
+      ]
     },
     {
       "id": "commodity-directive-with-metadata",
@@ -404,7 +487,10 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["commodity", "metadata"]
+      "tags": [
+        "commodity",
+        "metadata"
+      ]
     },
     {
       "id": "same-day-open-close",
@@ -417,7 +503,10 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["accounts", "edge-case"]
+      "tags": [
+        "accounts",
+        "edge-case"
+      ]
     },
     {
       "id": "negative-price",
@@ -430,7 +519,10 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["price", "edge-case"]
+      "tags": [
+        "price",
+        "edge-case"
+      ]
     },
     {
       "id": "zero-amount-posting",
@@ -443,7 +535,10 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["posting", "edge-case"]
+      "tags": [
+        "posting",
+        "edge-case"
+      ]
     },
     {
       "id": "expression-in-amount",
@@ -456,7 +551,10 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["amounts", "expression"]
+      "tags": [
+        "amounts",
+        "expression"
+      ]
     },
     {
       "id": "comments-everywhere",
@@ -469,7 +567,9 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["comments"]
+      "tags": [
+        "comments"
+      ]
     },
     {
       "id": "blank-lines-and-whitespace",
@@ -482,7 +582,9 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["whitespace"]
+      "tags": [
+        "whitespace"
+      ]
     },
     {
       "id": "tabs-for-indentation",
@@ -495,7 +597,10 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["whitespace", "tabs"]
+      "tags": [
+        "whitespace",
+        "tabs"
+      ]
     },
     {
       "id": "date-slash-separator",
@@ -508,7 +613,9 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["date"]
+      "tags": [
+        "date"
+      ]
     },
     {
       "id": "single-digit-date-parts",
@@ -521,7 +628,9 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["date"]
+      "tags": [
+        "date"
+      ]
     },
     {
       "id": "org-mode-headers-ignored",
@@ -534,7 +643,10 @@
         "parse": "success",
         "validate": "success"
       },
-      "tags": ["comments", "org-mode"]
+      "tags": [
+        "comments",
+        "org-mode"
+      ]
     }
   ]
 }

--- a/tests/beancount/v3/syntax/edge-cases/tests.json
+++ b/tests/beancount/v3/syntax/edge-cases/tests.json
@@ -4,274 +4,546 @@
   "description": "Edge cases and boundary conditions for Beancount syntax",
   "tests": [
     {
-      "id": "unicode-account-name",
+      "id": "unicode-account-name-edge",
       "description": "Account name with Unicode characters (rejected by Beancount)",
-      "input": {"inline": "2024-01-01 open Assets:銀行口座"},
-      "expected": {"parse": "error", "error_contains": ["Invalid account"]},
-      "tags": ["unicode", "account", "invalid"]
+      "input": {
+        "inline": "2024-01-01 open Assets:銀行口座"
+      },
+      "expected": {
+        "parse": "error",
+        "error_contains": [
+          "Invalid account"
+        ]
+      },
+      "tags": [
+        "unicode",
+        "account",
+        "invalid"
+      ]
     },
     {
-      "id": "unicode-narration",
+      "id": "unicode-narration-edge",
       "description": "Transaction with Unicode narration",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-15 * \"日本語の説明 🍣\"\n  Assets:A  -50 USD\n  Expenses:B"},
-      "expected": {"parse": "success"},
-      "tags": ["unicode", "transaction"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-15 * \"日本語の説明 🍣\"\n  Assets:A  -50 USD\n  Expenses:B"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "unicode",
+        "transaction"
+      ]
     },
     {
       "id": "unicode-payee",
       "description": "Transaction with Unicode payee",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-15 * \"株式会社ABC\" \"Payment\"\n  Assets:A  -50 USD\n  Expenses:B"},
-      "expected": {"parse": "success"},
-      "tags": ["unicode", "payee"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-15 * \"株式会社ABC\" \"Payment\"\n  Assets:A  -50 USD\n  Expenses:B"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "unicode",
+        "payee"
+      ]
     },
     {
       "id": "very-long-account-name",
       "description": "Account with many components",
-      "input": {"inline": "2024-01-01 open Assets:Bank:Checking:Personal:Main:Primary:Account:Number:One"},
-      "expected": {"parse": "success", "directives": 1},
-      "tags": ["account", "boundary"]
+      "input": {
+        "inline": "2024-01-01 open Assets:Bank:Checking:Personal:Main:Primary:Account:Number:One"
+      },
+      "expected": {
+        "parse": "success",
+        "directives": 1
+      },
+      "tags": [
+        "account",
+        "boundary"
+      ]
     },
     {
       "id": "single-letter-account-component",
       "description": "Account with single-letter components",
-      "input": {"inline": "2024-01-01 open Assets:A:B:C"},
-      "expected": {"parse": "success", "directives": 1},
-      "tags": ["account", "minimal"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A:B:C"
+      },
+      "expected": {
+        "parse": "success",
+        "directives": 1
+      },
+      "tags": [
+        "account",
+        "minimal"
+      ]
     },
     {
       "id": "max-decimal-precision",
       "description": "Amount with many decimal places",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"High precision\"\n  Assets:A  1.123456789012345678 USD\n  Assets:B"},
-      "expected": {"parse": "success"},
-      "tags": ["amount", "precision"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"High precision\"\n  Assets:A  1.123456789012345678 USD\n  Assets:B"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "amount",
+        "precision"
+      ]
     },
     {
-      "id": "very-large-amount",
+      "id": "very-large-amount-edge",
       "description": "Very large amount value",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"Large amount\"\n  Assets:A  999999999999999999.99 USD\n  Assets:B"},
-      "expected": {"parse": "success"},
-      "tags": ["amount", "boundary"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"Large amount\"\n  Assets:A  999999999999999999.99 USD\n  Assets:B"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "amount",
+        "boundary"
+      ]
     },
     {
-      "id": "very-small-amount",
+      "id": "very-small-amount-edge",
       "description": "Very small non-zero amount",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"Tiny amount\"\n  Assets:A  0.000000001 USD\n  Assets:B"},
-      "expected": {"parse": "success"},
-      "tags": ["amount", "boundary"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"Tiny amount\"\n  Assets:A  0.000000001 USD\n  Assets:B"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "amount",
+        "boundary"
+      ]
     },
     {
       "id": "negative-zero",
       "description": "Negative zero amount",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"Negative zero\"\n  Assets:A  -0.00 USD\n  Assets:B  0.00 USD"},
-      "expected": {"parse": "success"},
-      "tags": ["amount", "zero"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"Negative zero\"\n  Assets:A  -0.00 USD\n  Assets:B  0.00 USD"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "amount",
+        "zero"
+      ]
     },
     {
       "id": "date-year-boundaries",
       "description": "Transactions at year boundaries",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-12-31 * \"Last day\"\n  Assets:A  50 USD\n  Assets:B\n\n2025-01-01 * \"First day\"\n  Assets:A  -50 USD\n  Assets:B"},
-      "expected": {"parse": "success", "directives": 4},
-      "tags": ["date", "boundary"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-12-31 * \"Last day\"\n  Assets:A  50 USD\n  Assets:B\n\n2025-01-01 * \"First day\"\n  Assets:A  -50 USD\n  Assets:B"
+      },
+      "expected": {
+        "parse": "success",
+        "directives": 4
+      },
+      "tags": [
+        "date",
+        "boundary"
+      ]
     },
     {
-      "id": "leap-year-date",
+      "id": "leap-year-date-edge",
       "description": "Transaction on leap day",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-02-29 * \"Leap day\"\n  Assets:A  50 USD\n  Assets:B"},
-      "expected": {"parse": "success"},
-      "tags": ["date", "leap-year"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-02-29 * \"Leap day\"\n  Assets:A  50 USD\n  Assets:B"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "date",
+        "leap-year"
+      ]
     },
     {
       "id": "currency-all-caps-long",
       "description": "Long uppercase currency code",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n2024-01-01 commodity VERYLONGCURRENCY\n\n2024-01-15 * \"Test\"\n  Assets:A  50 VERYLONGCURRENCY\n  Assets:B -50 VERYLONGCURRENCY"},
-      "expected": {"parse": "success"},
-      "tags": ["currency", "boundary"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n2024-01-01 commodity VERYLONGCURRENCY\n\n2024-01-15 * \"Test\"\n  Assets:A  50 VERYLONGCURRENCY\n  Assets:B -50 VERYLONGCURRENCY"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "currency",
+        "boundary"
+      ]
     },
     {
       "id": "currency-with-numbers",
       "description": "Currency code with embedded numbers",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"Test\"\n  Assets:A  50 USD2024\n  Assets:B"},
-      "expected": {"parse": "success"},
-      "tags": ["currency"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"Test\"\n  Assets:A  50 USD2024\n  Assets:B"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "currency"
+      ]
     },
     {
       "id": "empty-narration",
       "description": "Transaction with empty narration",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"\"\n  Assets:A  50 USD\n  Assets:B"},
-      "expected": {"parse": "success"},
-      "tags": ["transaction", "empty"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"\"\n  Assets:A  50 USD\n  Assets:B"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "transaction",
+        "empty"
+      ]
     },
     {
       "id": "narration-with-quotes",
       "description": "Narration containing escaped quotes",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"He said \\\"hello\\\"\"\n  Assets:A  50 USD\n  Assets:B"},
-      "expected": {"parse": "success"},
-      "tags": ["string", "escape"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"He said \\\"hello\\\"\"\n  Assets:A  50 USD\n  Assets:B"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "string",
+        "escape"
+      ]
     },
     {
       "id": "narration-with-newlines",
       "description": "Narration with escaped newlines",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"Line 1\\nLine 2\"\n  Assets:A  50 USD\n  Assets:B"},
-      "expected": {"parse": "success"},
-      "tags": ["string", "escape"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"Line 1\\nLine 2\"\n  Assets:A  50 USD\n  Assets:B"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "string",
+        "escape"
+      ]
     },
     {
       "id": "multiple-tags",
       "description": "Transaction with many tags",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"Test\" #tag1 #tag2 #tag3 #tag4 #tag5\n  Assets:A  50 USD\n  Assets:B"},
-      "expected": {"parse": "success"},
-      "tags": ["tags", "multiple"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"Test\" #tag1 #tag2 #tag3 #tag4 #tag5\n  Assets:A  50 USD\n  Assets:B"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "tags",
+        "multiple"
+      ]
     },
     {
       "id": "multiple-links",
       "description": "Transaction with many links",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"Test\" ^link1 ^link2 ^link3 ^link4 ^link5\n  Assets:A  50 USD\n  Assets:B"},
-      "expected": {"parse": "success"},
-      "tags": ["links", "multiple"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"Test\" ^link1 ^link2 ^link3 ^link4 ^link5\n  Assets:A  50 USD\n  Assets:B"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "links",
+        "multiple"
+      ]
     },
     {
       "id": "many-postings",
       "description": "Transaction with many postings",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B1\n2024-01-01 open Expenses:B2\n2024-01-01 open Expenses:B3\n2024-01-01 open Expenses:B4\n2024-01-01 open Expenses:B5\n\n2024-01-15 * \"Many postings\"\n  Expenses:B1  10 USD\n  Expenses:B2  10 USD\n  Expenses:B3  10 USD\n  Expenses:B4  10 USD\n  Expenses:B5  10 USD\n  Assets:A"},
-      "expected": {"parse": "success"},
-      "tags": ["posting", "multiple"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B1\n2024-01-01 open Expenses:B2\n2024-01-01 open Expenses:B3\n2024-01-01 open Expenses:B4\n2024-01-01 open Expenses:B5\n\n2024-01-15 * \"Many postings\"\n  Expenses:B1  10 USD\n  Expenses:B2  10 USD\n  Expenses:B3  10 USD\n  Expenses:B4  10 USD\n  Expenses:B5  10 USD\n  Assets:A"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "posting",
+        "multiple"
+      ]
     },
     {
       "id": "deeply-nested-arithmetic",
       "description": "Complex arithmetic expression",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"Nested expression\"\n  Assets:A  ((100 + 50) * 2 / 3 - 10) USD\n  Assets:B"},
-      "expected": {"parse": "success"},
-      "tags": ["expression", "arithmetic"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"Nested expression\"\n  Assets:A  ((100 + 50) * 2 / 3 - 10) USD\n  Assets:B"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "expression",
+        "arithmetic"
+      ]
     },
     {
       "id": "cost-with-all-components",
       "description": "Cost specification with all optional components",
-      "input": {"inline": "2024-01-01 open Assets:Brokerage\n2024-01-01 open Assets:Cash\n\n2024-01-15 * \"Full cost spec\"\n  Assets:Brokerage  10 AAPL {150.00 USD, 2024-01-15, \"lot1\"}\n  Assets:Cash  -1500.00 USD"},
-      "expected": {"parse": "success"},
-      "tags": ["cost", "complete"]
+      "input": {
+        "inline": "2024-01-01 open Assets:Brokerage\n2024-01-01 open Assets:Cash\n\n2024-01-15 * \"Full cost spec\"\n  Assets:Brokerage  10 AAPL {150.00 USD, 2024-01-15, \"lot1\"}\n  Assets:Cash  -1500.00 USD"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "cost",
+        "complete"
+      ]
     },
     {
       "id": "price-and-cost-together",
       "description": "Posting with both cost and price",
-      "input": {"inline": "2024-01-01 open Assets:Brokerage\n2024-01-01 open Assets:Cash\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Sell with gain\"\n  Assets:Brokerage  -10 AAPL {100.00 USD} @ 150.00 USD\n  Assets:Cash  1500.00 USD\n  Income:Gains"},
-      "expected": {"parse": "success"},
-      "tags": ["cost", "price"]
+      "input": {
+        "inline": "2024-01-01 open Assets:Brokerage\n2024-01-01 open Assets:Cash\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Sell with gain\"\n  Assets:Brokerage  -10 AAPL {100.00 USD} @ 150.00 USD\n  Assets:Cash  1500.00 USD\n  Income:Gains"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "cost",
+        "price"
+      ]
     },
     {
       "id": "metadata-special-characters",
       "description": "Metadata with various value types",
-      "input": {"inline": "2024-01-01 open Assets:A\n  url: \"https://example.com/path?q=1&r=2\"\n  count: 42\n  rate: 3.14\n  date: 2024-01-01"},
-      "expected": {"parse": "success"},
-      "tags": ["metadata", "types"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n  url: \"https://example.com/path?q=1&r=2\"\n  count: 42\n  rate: 3.14\n  date: 2024-01-01"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "metadata",
+        "types"
+      ]
     },
     {
       "id": "consecutive-transactions",
       "description": "Many consecutive transactions",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-01 * \"T1\"\n  Assets:A  -10 USD\n  Expenses:B\n\n2024-01-02 * \"T2\"\n  Assets:A  -10 USD\n  Expenses:B\n\n2024-01-03 * \"T3\"\n  Assets:A  -10 USD\n  Expenses:B\n\n2024-01-04 * \"T4\"\n  Assets:A  -10 USD\n  Expenses:B\n\n2024-01-05 * \"T5\"\n  Assets:A  -10 USD\n  Expenses:B"},
-      "expected": {"parse": "success", "directives": 7},
-      "tags": ["transaction", "multiple"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-01 * \"T1\"\n  Assets:A  -10 USD\n  Expenses:B\n\n2024-01-02 * \"T2\"\n  Assets:A  -10 USD\n  Expenses:B\n\n2024-01-03 * \"T3\"\n  Assets:A  -10 USD\n  Expenses:B\n\n2024-01-04 * \"T4\"\n  Assets:A  -10 USD\n  Expenses:B\n\n2024-01-05 * \"T5\"\n  Assets:A  -10 USD\n  Expenses:B"
+      },
+      "expected": {
+        "parse": "success",
+        "directives": 7
+      },
+      "tags": [
+        "transaction",
+        "multiple"
+      ]
     },
     {
       "id": "mixed-whitespace",
       "description": "Transaction with mixed indentation styles",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"Mixed whitespace\"\n  Assets:A  50 USD\n\tAssets:B  -50 USD"},
-      "expected": {"parse": "success"},
-      "tags": ["whitespace"],
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"Mixed whitespace\"\n  Assets:A  50 USD\n\tAssets:B  -50 USD"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "whitespace"
+      ],
       "skip": true,
       "skip_reason": "Mixed tab/space indentation may be implementation-specific"
     },
     {
       "id": "comment-in-transaction",
       "description": "Comments between postings",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"With comments\"\n  ; Comment before first posting\n  Assets:A  50 USD  ; Inline comment\n  ; Comment before second posting\n  Assets:B  -50 USD"},
-      "expected": {"parse": "success"},
-      "tags": ["comment", "transaction"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"With comments\"\n  ; Comment before first posting\n  Assets:A  50 USD  ; Inline comment\n  ; Comment before second posting\n  Assets:B  -50 USD"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "comment",
+        "transaction"
+      ]
     },
     {
       "id": "empty-lines-in-transaction",
       "description": "Empty lines within transaction",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"Empty lines\"\n  Assets:A  50 USD\n\n  Assets:B  -50 USD"},
-      "expected": {"parse": "success"},
-      "tags": ["whitespace", "transaction"],
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"Empty lines\"\n  Assets:A  50 USD\n\n  Assets:B  -50 USD"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "whitespace",
+        "transaction"
+      ],
       "skip": true,
       "skip_reason": "Empty lines within transaction may end the transaction in some implementations"
     },
     {
       "id": "account-starting-with-number",
       "description": "Account component starting with digit",
-      "input": {"inline": "2024-01-01 open Assets:401k"},
-      "expected": {"parse": "success"},
-      "tags": ["account", "digit"]
+      "input": {
+        "inline": "2024-01-01 open Assets:401k"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "account",
+        "digit"
+      ]
     },
     {
       "id": "account-with-hyphen",
       "description": "Account with hyphenated component",
-      "input": {"inline": "2024-01-01 open Assets:Tax-Advantaged"},
-      "expected": {"parse": "success"},
-      "tags": ["account", "hyphen"]
+      "input": {
+        "inline": "2024-01-01 open Assets:Tax-Advantaged"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "account",
+        "hyphen"
+      ]
     },
     {
       "id": "minimum-valid-transaction",
       "description": "Minimum valid transaction with proper account format",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-01 * \"\"\n  Assets:A  0 USD\n  Expenses:B"},
-      "expected": {"parse": "success"},
-      "tags": ["minimal", "boundary"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-01 * \"\"\n  Assets:A  0 USD\n  Expenses:B"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "minimal",
+        "boundary"
+      ]
     },
     {
-      "id": "balance-with-tolerance",
+      "id": "balance-with-tolerance-edge",
       "description": "Balance assertion with explicit tolerance",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Equity:Opening\n\n2024-01-02 * \"Deposit\"\n  Assets:A  100.00 USD\n  Equity:Opening\n\n2024-01-15 balance Assets:A  100.00 ~ 0.01 USD"},
-      "expected": {"parse": "success"},
-      "tags": ["balance", "tolerance"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Equity:Opening\n\n2024-01-02 * \"Deposit\"\n  Assets:A  100.00 USD\n  Equity:Opening\n\n2024-01-15 balance Assets:A  100.00 ~ 0.01 USD"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "balance",
+        "tolerance"
+      ]
     },
     {
-      "id": "pad-directive",
+      "id": "pad-directive-edge",
       "description": "Pad directive with equity account",
-      "input": {"inline": "2024-01-01 open Assets:Checking\n2024-01-01 open Equity:Opening\n\n2024-01-15 pad Assets:Checking Equity:Opening\n\n2024-02-01 balance Assets:Checking  1000.00 USD"},
-      "expected": {"parse": "success"},
-      "tags": ["pad", "directive"]
+      "input": {
+        "inline": "2024-01-01 open Assets:Checking\n2024-01-01 open Equity:Opening\n\n2024-01-15 pad Assets:Checking Equity:Opening\n\n2024-02-01 balance Assets:Checking  1000.00 USD"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "pad",
+        "directive"
+      ]
     },
     {
       "id": "plugin-with-config",
       "description": "Plugin directive with configuration",
-      "input": {"inline": "plugin \"beancount.plugins.auto_accounts\""},
-      "expected": {"parse": "success"},
-      "tags": ["plugin", "directive"]
+      "input": {
+        "inline": "plugin \"beancount.plugins.auto_accounts\""
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "plugin",
+        "directive"
+      ]
     },
     {
       "id": "option-custom",
       "description": "Custom option value",
-      "input": {"inline": "option \"insert_pythonpath\" \"True\""},
-      "expected": {"parse": "success"},
-      "tags": ["option", "directive"]
+      "input": {
+        "inline": "option \"insert_pythonpath\" \"True\""
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "option",
+        "directive"
+      ]
     },
     {
-      "id": "query-directive",
+      "id": "query-directive-edge",
       "description": "Named query directive",
-      "input": {"inline": "2024-01-01 query \"expenses-by-month\" \"SELECT month, sum(position) WHERE account ~ 'Expenses' GROUP BY month\""},
-      "expected": {"parse": "success"},
-      "tags": ["query", "directive"]
+      "input": {
+        "inline": "2024-01-01 query \"expenses-by-month\" \"SELECT month, sum(position) WHERE account ~ 'Expenses' GROUP BY month\""
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "query",
+        "directive"
+      ]
     },
     {
-      "id": "event-directive",
+      "id": "event-directive-edge",
       "description": "Event directive",
-      "input": {"inline": "2024-01-01 event \"location\" \"New York\""},
-      "expected": {"parse": "success"},
-      "tags": ["event", "directive"]
+      "input": {
+        "inline": "2024-01-01 event \"location\" \"New York\""
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "event",
+        "directive"
+      ]
     },
     {
-      "id": "note-directive",
+      "id": "note-directive-edge",
       "description": "Note directive on account",
-      "input": {"inline": "2024-01-01 open Assets:Checking\n\n2024-01-15 note Assets:Checking \"Updated account settings\""},
-      "expected": {"parse": "success"},
-      "tags": ["note", "directive"]
+      "input": {
+        "inline": "2024-01-01 open Assets:Checking\n\n2024-01-15 note Assets:Checking \"Updated account settings\""
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "note",
+        "directive"
+      ]
     },
     {
-      "id": "custom-directive",
+      "id": "custom-directive-edge",
       "description": "Custom directive with multiple values",
-      "input": {"inline": "2024-01-01 custom \"budget\" Assets:Food 500.00 USD \"monthly\""},
-      "expected": {"parse": "success"},
-      "tags": ["custom", "directive"]
+      "input": {
+        "inline": "2024-01-01 custom \"budget\" Assets:Food 500.00 USD \"monthly\""
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "custom",
+        "directive"
+      ]
     }
   ]
 }

--- a/tests/beancount/v3/syntax/valid/tests.json
+++ b/tests/beancount/v3/syntax/valid/tests.json
@@ -6,347 +6,701 @@
     {
       "id": "empty-file",
       "description": "Empty file is valid",
-      "input": {"inline": ""},
-      "expected": {"parse": "success", "directives": 0},
-      "tags": ["minimal"]
+      "input": {
+        "inline": ""
+      },
+      "expected": {
+        "parse": "success",
+        "directives": 0
+      },
+      "tags": [
+        "minimal"
+      ]
     },
     {
       "id": "comment-only",
       "description": "File with only comments",
-      "input": {"inline": "; This is a comment\n; Another comment"},
-      "expected": {"parse": "success", "directives": 0},
-      "tags": ["comments"]
+      "input": {
+        "inline": "; This is a comment\n; Another comment"
+      },
+      "expected": {
+        "parse": "success",
+        "directives": 0
+      },
+      "tags": [
+        "comments"
+      ]
     },
     {
       "id": "open-minimal",
       "description": "Minimal open directive",
-      "input": {"inline": "2024-01-01 open Assets:Checking"},
-      "expected": {"parse": "success", "directives": 1},
-      "tags": ["open", "directives"]
+      "input": {
+        "inline": "2024-01-01 open Assets:Checking"
+      },
+      "expected": {
+        "parse": "success",
+        "directives": 1
+      },
+      "tags": [
+        "open",
+        "directives"
+      ]
     },
     {
       "id": "open-with-currency",
       "description": "Open with currency constraint",
-      "input": {"inline": "2024-01-01 open Assets:Checking USD"},
-      "expected": {"parse": "success", "directives": 1},
-      "tags": ["open", "currency"]
+      "input": {
+        "inline": "2024-01-01 open Assets:Checking USD"
+      },
+      "expected": {
+        "parse": "success",
+        "directives": 1
+      },
+      "tags": [
+        "open",
+        "currency"
+      ]
     },
     {
       "id": "open-multi-currency",
       "description": "Open with multiple currencies",
-      "input": {"inline": "2024-01-01 open Assets:Brokerage USD,EUR,AAPL"},
-      "expected": {"parse": "success", "directives": 1},
-      "tags": ["open", "currency"]
+      "input": {
+        "inline": "2024-01-01 open Assets:Brokerage USD,EUR,AAPL"
+      },
+      "expected": {
+        "parse": "success",
+        "directives": 1
+      },
+      "tags": [
+        "open",
+        "currency"
+      ]
     },
     {
       "id": "open-with-booking",
       "description": "Open with booking method",
-      "input": {"inline": "2024-01-01 open Assets:Stock AAPL \"FIFO\""},
-      "expected": {"parse": "success", "directives": 1},
-      "tags": ["open", "booking"]
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock AAPL \"FIFO\""
+      },
+      "expected": {
+        "parse": "success",
+        "directives": 1
+      },
+      "tags": [
+        "open",
+        "booking"
+      ]
     },
     {
       "id": "close-minimal",
       "description": "Minimal close directive",
-      "input": {"inline": "2024-01-01 open Assets:Old\n2024-12-31 close Assets:Old"},
-      "expected": {"parse": "success", "directives": 2},
-      "tags": ["close", "directives"]
+      "input": {
+        "inline": "2024-01-01 open Assets:Old\n2024-12-31 close Assets:Old"
+      },
+      "expected": {
+        "parse": "success",
+        "directives": 2
+      },
+      "tags": [
+        "close",
+        "directives"
+      ]
     },
     {
       "id": "transaction-minimal",
       "description": "Minimal transaction with two postings",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"Test\"\n  Assets:A  100 USD\n  Assets:B -100 USD"},
-      "expected": {"parse": "success", "validate": "success"},
-      "tags": ["transaction", "minimal"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"Test\"\n  Assets:A  100 USD\n  Assets:B -100 USD"
+      },
+      "expected": {
+        "parse": "success",
+        "validate": "success"
+      },
+      "tags": [
+        "transaction",
+        "minimal"
+      ]
     },
     {
       "id": "transaction-complete-flag",
       "description": "Transaction with * flag",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-15 * \"Complete transaction\"\n  Assets:A  -50 USD\n  Expenses:B"},
-      "expected": {"parse": "success"},
-      "tags": ["transaction", "flag"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-15 * \"Complete transaction\"\n  Assets:A  -50 USD\n  Expenses:B"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "transaction",
+        "flag"
+      ]
     },
     {
       "id": "transaction-incomplete-flag",
       "description": "Transaction with ! flag",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-15 ! \"Incomplete transaction\"\n  Assets:A  -50 USD\n  Expenses:B"},
-      "expected": {"parse": "success"},
-      "tags": ["transaction", "flag"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-15 ! \"Incomplete transaction\"\n  Assets:A  -50 USD\n  Expenses:B"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "transaction",
+        "flag"
+      ]
     },
     {
       "id": "transaction-txn-keyword",
       "description": "Transaction with txn keyword",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-15 txn \"Using txn keyword\"\n  Assets:A  -50 USD\n  Expenses:B"},
-      "expected": {"parse": "success"},
-      "tags": ["transaction", "flag"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-15 txn \"Using txn keyword\"\n  Assets:A  -50 USD\n  Expenses:B"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "transaction",
+        "flag"
+      ]
     },
     {
       "id": "transaction-payee-narration",
       "description": "Transaction with payee and narration",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-15 * \"Payee Name\" \"Description here\"\n  Assets:A  -50 USD\n  Expenses:B"},
-      "expected": {"parse": "success"},
-      "tags": ["transaction", "payee"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-15 * \"Payee Name\" \"Description here\"\n  Assets:A  -50 USD\n  Expenses:B"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "transaction",
+        "payee"
+      ]
     },
     {
       "id": "transaction-tags",
       "description": "Transaction with tags",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-15 * \"Tagged\" #travel #business\n  Assets:A  -50 USD\n  Expenses:B"},
-      "expected": {"parse": "success"},
-      "tags": ["transaction", "tags"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-15 * \"Tagged\" #travel #business\n  Assets:A  -50 USD\n  Expenses:B"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "transaction",
+        "tags"
+      ]
     },
     {
       "id": "transaction-links",
       "description": "Transaction with links",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-15 * \"Linked\" ^invoice-123 ^ref-456\n  Assets:A  -50 USD\n  Expenses:B"},
-      "expected": {"parse": "success"},
-      "tags": ["transaction", "links"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-15 * \"Linked\" ^invoice-123 ^ref-456\n  Assets:A  -50 USD\n  Expenses:B"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "transaction",
+        "links"
+      ]
     },
     {
       "id": "transaction-elided-amount",
       "description": "Transaction with one elided amount",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-15 * \"Elided\"\n  Assets:A  -100 USD\n  Expenses:B"},
-      "expected": {"parse": "success", "validate": "success"},
-      "tags": ["transaction", "elision"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-15 * \"Elided\"\n  Assets:A  -100 USD\n  Expenses:B"
+      },
+      "expected": {
+        "parse": "success",
+        "validate": "success"
+      },
+      "tags": [
+        "transaction",
+        "elision"
+      ]
     },
     {
       "id": "amount-positive",
       "description": "Positive amount with + sign",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 *\n  Assets:A  +100 USD\n  Assets:B -100 USD"},
-      "expected": {"parse": "success"},
-      "tags": ["amount", "sign"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 *\n  Assets:A  +100 USD\n  Assets:B -100 USD"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "amount",
+        "sign"
+      ]
     },
     {
       "id": "amount-grouping",
       "description": "Amount with thousand separators",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 *\n  Assets:A  1,234,567.89 USD\n  Assets:B -1,234,567.89 USD"},
-      "expected": {"parse": "success"},
-      "tags": ["amount", "grouping"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 *\n  Assets:A  1,234,567.89 USD\n  Assets:B -1,234,567.89 USD"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "amount",
+        "grouping"
+      ]
     },
     {
       "id": "amount-expression",
       "description": "Amount with arithmetic expression",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 *\n  Assets:A  (100 + 50) USD\n  Assets:B -(100 + 50) USD"},
-      "expected": {"parse": "success"},
-      "tags": ["amount", "expression"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 *\n  Assets:A  (100 + 50) USD\n  Assets:B -(100 + 50) USD"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "amount",
+        "expression"
+      ]
     },
     {
       "id": "balance-assertion",
       "description": "Balance assertion directive",
-      "input": {"inline": "2024-01-01 open Assets:Checking USD\n\n2024-01-15 balance Assets:Checking 0 USD"},
-      "expected": {"parse": "success", "validate": "success"},
-      "tags": ["balance", "directives"]
+      "input": {
+        "inline": "2024-01-01 open Assets:Checking USD\n\n2024-01-15 balance Assets:Checking 0 USD"
+      },
+      "expected": {
+        "parse": "success",
+        "validate": "success"
+      },
+      "tags": [
+        "balance",
+        "directives"
+      ]
     },
     {
-      "id": "balance-with-tolerance",
+      "id": "balance-with-tolerance-valid",
       "description": "Balance assertion with explicit tolerance",
-      "input": {"inline": "2024-01-01 open Assets:Checking USD\n\n2024-01-15 balance Assets:Checking 0.00 ~ 0.01 USD"},
-      "expected": {"parse": "success"},
-      "tags": ["balance", "tolerance"]
+      "input": {
+        "inline": "2024-01-01 open Assets:Checking USD\n\n2024-01-15 balance Assets:Checking 0.00 ~ 0.01 USD"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "balance",
+        "tolerance"
+      ]
     },
     {
-      "id": "pad-directive",
+      "id": "pad-directive-valid",
       "description": "Pad directive",
-      "input": {"inline": "2024-01-01 open Assets:Checking USD\n2024-01-01 open Equity:Opening USD\n\n2024-01-01 pad Assets:Checking Equity:Opening\n2024-01-02 balance Assets:Checking 1000 USD"},
-      "expected": {"parse": "success"},
-      "tags": ["pad", "directives"]
+      "input": {
+        "inline": "2024-01-01 open Assets:Checking USD\n2024-01-01 open Equity:Opening USD\n\n2024-01-01 pad Assets:Checking Equity:Opening\n2024-01-02 balance Assets:Checking 1000 USD"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "pad",
+        "directives"
+      ]
     },
     {
       "id": "commodity-directive",
       "description": "Commodity declaration",
-      "input": {"inline": "2024-01-01 commodity USD"},
-      "expected": {"parse": "success", "directives": 1},
-      "tags": ["commodity", "directives"]
+      "input": {
+        "inline": "2024-01-01 commodity USD"
+      },
+      "expected": {
+        "parse": "success",
+        "directives": 1
+      },
+      "tags": [
+        "commodity",
+        "directives"
+      ]
     },
     {
       "id": "commodity-with-metadata",
       "description": "Commodity with metadata",
-      "input": {"inline": "2024-01-01 commodity AAPL\n  name: \"Apple Inc.\"\n  asset-class: \"stock\""},
-      "expected": {"parse": "success"},
-      "tags": ["commodity", "metadata"]
+      "input": {
+        "inline": "2024-01-01 commodity AAPL\n  name: \"Apple Inc.\"\n  asset-class: \"stock\""
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "commodity",
+        "metadata"
+      ]
     },
     {
       "id": "price-directive",
       "description": "Price directive",
-      "input": {"inline": "2024-01-15 price AAPL 185.50 USD"},
-      "expected": {"parse": "success", "directives": 1},
-      "tags": ["price", "directives"]
+      "input": {
+        "inline": "2024-01-15 price AAPL 185.50 USD"
+      },
+      "expected": {
+        "parse": "success",
+        "directives": 1
+      },
+      "tags": [
+        "price",
+        "directives"
+      ]
     },
     {
-      "id": "event-directive",
+      "id": "event-directive-valid",
       "description": "Event directive",
-      "input": {"inline": "2024-01-15 event \"location\" \"New York\""},
-      "expected": {"parse": "success", "directives": 1},
-      "tags": ["event", "directives"]
+      "input": {
+        "inline": "2024-01-15 event \"location\" \"New York\""
+      },
+      "expected": {
+        "parse": "success",
+        "directives": 1
+      },
+      "tags": [
+        "event",
+        "directives"
+      ]
     },
     {
-      "id": "note-directive",
+      "id": "note-directive-valid",
       "description": "Note directive",
-      "input": {"inline": "2024-01-01 open Assets:Checking\n\n2024-01-15 note Assets:Checking \"Account opened online\""},
-      "expected": {"parse": "success"},
-      "tags": ["note", "directives"]
+      "input": {
+        "inline": "2024-01-01 open Assets:Checking\n\n2024-01-15 note Assets:Checking \"Account opened online\""
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "note",
+        "directives"
+      ]
     },
     {
       "id": "document-directive",
       "description": "Document directive",
       "skip": true,
       "skip_reason": "Document validation checks file existence during load - requires test fixture file",
-      "input": {"inline": "2024-01-01 open Assets:Checking\n\n2024-01-15 document Assets:Checking \"statement.pdf\""},
-      "expected": {"parse": "success"},
-      "tags": ["document", "directives"]
+      "input": {
+        "inline": "2024-01-01 open Assets:Checking\n\n2024-01-15 document Assets:Checking \"statement.pdf\""
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "document",
+        "directives"
+      ]
     },
     {
-      "id": "query-directive",
+      "id": "query-directive-valid",
       "description": "Query directive",
-      "input": {"inline": "2024-01-15 query \"balance-check\" \"SELECT account, sum(position) GROUP BY account\""},
-      "expected": {"parse": "success", "directives": 1},
-      "tags": ["query", "directives"]
+      "input": {
+        "inline": "2024-01-15 query \"balance-check\" \"SELECT account, sum(position) GROUP BY account\""
+      },
+      "expected": {
+        "parse": "success",
+        "directives": 1
+      },
+      "tags": [
+        "query",
+        "directives"
+      ]
     },
     {
-      "id": "custom-directive",
+      "id": "custom-directive-valid",
       "description": "Custom directive",
-      "input": {"inline": "2024-01-15 custom \"budget\" Expenses:Food 500 USD"},
-      "expected": {"parse": "success", "directives": 1},
-      "tags": ["custom", "directives"]
+      "input": {
+        "inline": "2024-01-15 custom \"budget\" Expenses:Food 500 USD"
+      },
+      "expected": {
+        "parse": "success",
+        "directives": 1
+      },
+      "tags": [
+        "custom",
+        "directives"
+      ]
     },
     {
       "id": "option-title",
       "description": "Option directive",
-      "input": {"inline": "option \"title\" \"My Ledger\""},
-      "expected": {"parse": "success", "directives": 0},
-      "tags": ["option", "directives"]
+      "input": {
+        "inline": "option \"title\" \"My Ledger\""
+      },
+      "expected": {
+        "parse": "success",
+        "directives": 0
+      },
+      "tags": [
+        "option",
+        "directives"
+      ]
     },
     {
       "id": "option-operating-currency",
       "description": "Operating currency option",
-      "input": {"inline": "option \"operating_currency\" \"USD\""},
-      "expected": {"parse": "success"},
-      "tags": ["option"]
+      "input": {
+        "inline": "option \"operating_currency\" \"USD\""
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "option"
+      ]
     },
     {
       "id": "plugin-directive",
       "description": "Plugin directive",
-      "input": {"inline": "plugin \"beancount.plugins.auto_accounts\""},
-      "expected": {"parse": "success", "directives": 0},
-      "tags": ["plugin", "directives"]
+      "input": {
+        "inline": "plugin \"beancount.plugins.auto_accounts\""
+      },
+      "expected": {
+        "parse": "success",
+        "directives": 0
+      },
+      "tags": [
+        "plugin",
+        "directives"
+      ]
     },
     {
-      "id": "cost-per-unit",
+      "id": "cost-per-unit-valid",
       "description": "Posting with per-unit cost",
-      "input": {"inline": "2024-01-01 open Assets:Stock\n2024-01-01 open Assets:Cash USD\n\n2024-01-15 *\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD"},
-      "expected": {"parse": "success", "validate": "success"},
-      "tags": ["cost", "booking"]
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock\n2024-01-01 open Assets:Cash USD\n\n2024-01-15 *\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD"
+      },
+      "expected": {
+        "parse": "success",
+        "validate": "success"
+      },
+      "tags": [
+        "cost",
+        "booking"
+      ]
     },
     {
-      "id": "cost-total",
+      "id": "cost-total-valid",
       "description": "Posting with total cost",
-      "input": {"inline": "2024-01-01 open Assets:Stock\n2024-01-01 open Assets:Cash USD\n\n2024-01-15 *\n  Assets:Stock 10 AAPL {{1500 USD}}\n  Assets:Cash -1500 USD"},
-      "expected": {"parse": "success"},
-      "tags": ["cost", "booking"]
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock\n2024-01-01 open Assets:Cash USD\n\n2024-01-15 *\n  Assets:Stock 10 AAPL {{1500 USD}}\n  Assets:Cash -1500 USD"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "cost",
+        "booking"
+      ]
     },
     {
-      "id": "cost-with-date",
+      "id": "cost-with-date-valid",
       "description": "Cost with acquisition date",
-      "input": {"inline": "2024-01-01 open Assets:Stock\n2024-01-01 open Assets:Cash USD\n\n2024-01-15 *\n  Assets:Stock 10 AAPL {150 USD, 2024-01-15}\n  Assets:Cash -1500 USD"},
-      "expected": {"parse": "success"},
-      "tags": ["cost", "booking"]
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock\n2024-01-01 open Assets:Cash USD\n\n2024-01-15 *\n  Assets:Stock 10 AAPL {150 USD, 2024-01-15}\n  Assets:Cash -1500 USD"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "cost",
+        "booking"
+      ]
     },
     {
-      "id": "cost-with-label",
+      "id": "cost-with-label-valid",
       "description": "Cost with lot label",
-      "input": {"inline": "2024-01-01 open Assets:Stock\n2024-01-01 open Assets:Cash USD\n\n2024-01-15 *\n  Assets:Stock 10 AAPL {150 USD, \"lot1\"}\n  Assets:Cash -1500 USD"},
-      "expected": {"parse": "success"},
-      "tags": ["cost", "booking"]
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock\n2024-01-01 open Assets:Cash USD\n\n2024-01-15 *\n  Assets:Stock 10 AAPL {150 USD, \"lot1\"}\n  Assets:Cash -1500 USD"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "cost",
+        "booking"
+      ]
     },
     {
-      "id": "price-annotation",
+      "id": "price-annotation-valid",
       "description": "Posting with price annotation",
-      "input": {"inline": "2024-01-01 open Assets:EUR\n2024-01-01 open Assets:USD\n\n2024-01-15 *\n  Assets:EUR 100 EUR @ 1.10 USD\n  Assets:USD -110 USD"},
-      "expected": {"parse": "success", "validate": "success"},
-      "tags": ["price", "conversion"]
+      "input": {
+        "inline": "2024-01-01 open Assets:EUR\n2024-01-01 open Assets:USD\n\n2024-01-15 *\n  Assets:EUR 100 EUR @ 1.10 USD\n  Assets:USD -110 USD"
+      },
+      "expected": {
+        "parse": "success",
+        "validate": "success"
+      },
+      "tags": [
+        "price",
+        "conversion"
+      ]
     },
     {
-      "id": "price-total-annotation",
+      "id": "price-total-annotation-valid",
       "description": "Posting with total price annotation",
-      "input": {"inline": "2024-01-01 open Assets:EUR\n2024-01-01 open Assets:USD\n\n2024-01-15 *\n  Assets:EUR 100 EUR @@ 110 USD\n  Assets:USD -110 USD"},
-      "expected": {"parse": "success"},
-      "tags": ["price", "conversion"]
+      "input": {
+        "inline": "2024-01-01 open Assets:EUR\n2024-01-01 open Assets:USD\n\n2024-01-15 *\n  Assets:EUR 100 EUR @@ 110 USD\n  Assets:USD -110 USD"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "price",
+        "conversion"
+      ]
     },
     {
       "id": "metadata-directive",
       "description": "Directive with metadata",
-      "input": {"inline": "2024-01-01 open Assets:Checking USD\n  institution: \"Bank of America\"\n  account-number: \"1234\""},
-      "expected": {"parse": "success"},
-      "tags": ["metadata"]
+      "input": {
+        "inline": "2024-01-01 open Assets:Checking USD\n  institution: \"Bank of America\"\n  account-number: \"1234\""
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "metadata"
+      ]
     },
     {
       "id": "metadata-posting",
       "description": "Posting with metadata",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 *\n  Assets:A 100 USD\n    note: \"test\"\n  Assets:B -100 USD"},
-      "expected": {"parse": "success"},
-      "tags": ["metadata", "posting"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 *\n  Assets:A 100 USD\n    note: \"test\"\n  Assets:B -100 USD"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "metadata",
+        "posting"
+      ]
     },
     {
-      "id": "pushtag-poptag",
+      "id": "pushtag-poptag-valid",
       "description": "Tag stack directives",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\npushtag #project\n\n2024-01-15 * \"Tagged\"\n  Assets:A -100 USD\n  Expenses:B\n\npoptag #project"},
-      "expected": {"parse": "success"},
-      "tags": ["tags", "stack"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\npushtag #project\n\n2024-01-15 * \"Tagged\"\n  Assets:A -100 USD\n  Expenses:B\n\npoptag #project"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "tags",
+        "stack"
+      ]
     },
     {
-      "id": "pushmeta-popmeta",
+      "id": "pushmeta-popmeta-valid",
       "description": "Metadata stack directives",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\npushmeta location: \"NYC\"\n\n2024-01-15 * \"With meta\"\n  Assets:A -100 USD\n  Expenses:B\n\npopmeta location:"},
-      "expected": {"parse": "success"},
-      "tags": ["metadata", "stack"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\npushmeta location: \"NYC\"\n\n2024-01-15 * \"With meta\"\n  Assets:A -100 USD\n  Expenses:B\n\npopmeta location:"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "metadata",
+        "stack"
+      ]
     },
     {
       "id": "string-escaped-quote",
       "description": "String with escaped quote",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-15 * \"Test \\\"quoted\\\" text\"\n  Assets:A -100 USD\n  Expenses:B"},
-      "expected": {"parse": "success"},
-      "tags": ["lexical", "string"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-15 * \"Test \\\"quoted\\\" text\"\n  Assets:A -100 USD\n  Expenses:B"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "lexical",
+        "string"
+      ]
     },
     {
       "id": "string-escaped-backslash",
       "description": "String with escaped backslash",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-15 * \"Path: C:\\\\Users\\\\\"\n  Assets:A -100 USD\n  Expenses:B"},
-      "expected": {"parse": "success"},
-      "tags": ["lexical", "string"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-15 * \"Path: C:\\\\Users\\\\\"\n  Assets:A -100 USD\n  Expenses:B"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "lexical",
+        "string"
+      ]
     },
     {
       "id": "date-slash-format",
       "description": "Date with slash separator",
-      "input": {"inline": "2024/01/01 open Assets:Checking"},
-      "expected": {"parse": "success"},
-      "tags": ["lexical", "date"]
+      "input": {
+        "inline": "2024/01/01 open Assets:Checking"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "lexical",
+        "date"
+      ]
     },
     {
       "id": "account-with-digit",
       "description": "Account component starting with digit",
-      "input": {"inline": "2024-01-01 open Assets:401k"},
-      "expected": {"parse": "success"},
-      "tags": ["account"]
+      "input": {
+        "inline": "2024-01-01 open Assets:401k"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "account"
+      ]
     },
     {
       "id": "currency-two-char",
       "description": "Two character currency (minimum length)",
-      "input": {"inline": "2024-01-01 open Assets:A AU\n\n2024-01-15 balance Assets:A 0 AU"},
-      "expected": {"parse": "success"},
-      "tags": ["currency"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A AU\n\n2024-01-15 balance Assets:A 0 AU"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "currency"
+      ]
     },
     {
       "id": "currency-with-dot",
       "description": "Currency with dot (e.g., stock ticker)",
-      "input": {"inline": "2024-01-01 open Assets:Stock BRK.B"},
-      "expected": {"parse": "success"},
-      "tags": ["currency"]
+      "input": {
+        "inline": "2024-01-01 open Assets:Stock BRK.B"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "currency"
+      ]
     },
     {
       "id": "tag-with-period",
       "description": "Tag containing period",
-      "input": {"inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-15 * \"Test\" #project.v1\n  Assets:A -100 USD\n  Expenses:B"},
-      "expected": {"parse": "success"},
-      "tags": ["tags"]
+      "input": {
+        "inline": "2024-01-01 open Assets:A\n2024-01-01 open Expenses:B\n\n2024-01-15 * \"Test\" #project.v1\n  Assets:A -100 USD\n  Expenses:B"
+      },
+      "expected": {
+        "parse": "success"
+      },
+      "tags": [
+        "tags"
+      ]
     }
   ]
 }

--- a/tests/cross-format/beancount-to-hledger/tests.json
+++ b/tests/cross-format/beancount-to-hledger/tests.json
@@ -4,7 +4,7 @@
   "description": "Beancount to hledger format conversion tests",
   "tests": [
     {
-      "id": "simple-transaction",
+      "id": "simple-transaction-b2h",
       "description": "Basic transaction converts correctly",
       "source": {
         "format": "beancount",
@@ -16,11 +16,18 @@
       "expected": {
         "convert": "success",
         "balance": {
-          "expenses:food": {"USD": "50.00"},
-          "assets:checking": {"USD": "-50.00"}
+          "expenses:food": {
+            "USD": "50.00"
+          },
+          "assets:checking": {
+            "USD": "-50.00"
+          }
         }
       },
-      "tags": ["transaction", "basic"]
+      "tags": [
+        "transaction",
+        "basic"
+      ]
     },
     {
       "id": "account-case-conversion",
@@ -34,12 +41,17 @@
       },
       "expected": {
         "convert": "success",
-        "accounts": ["assets:bank:checking"]
+        "accounts": [
+          "assets:bank:checking"
+        ]
       },
-      "tags": ["account", "case"]
+      "tags": [
+        "account",
+        "case"
+      ]
     },
     {
-      "id": "transaction-with-tags",
+      "id": "transaction-with-tags-b2h",
       "description": "Tags convert to hledger tags",
       "source": {
         "format": "beancount",
@@ -51,10 +63,12 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["tags"]
+      "tags": [
+        "tags"
+      ]
     },
     {
-      "id": "balance-assertion",
+      "id": "balance-assertion-b2h",
       "description": "Balance assertion converts",
       "source": {
         "format": "beancount",
@@ -66,10 +80,13 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["balance", "assertion"]
+      "tags": [
+        "balance",
+        "assertion"
+      ]
     },
     {
-      "id": "lot-with-price",
+      "id": "lot-with-price-b2h",
       "description": "Lot with price annotation converts",
       "source": {
         "format": "beancount",
@@ -81,7 +98,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["lot", "price"]
+      "tags": [
+        "lot",
+        "price"
+      ]
     },
     {
       "id": "multi-posting-metadata",
@@ -96,7 +116,9 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["metadata"]
+      "tags": [
+        "metadata"
+      ]
     },
     {
       "id": "payee-narration",
@@ -111,10 +133,13 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["description", "payee"]
+      "tags": [
+        "description",
+        "payee"
+      ]
     },
     {
-      "id": "price-directive",
+      "id": "price-directive-b2h",
       "description": "Price directive converts to P directive",
       "source": {
         "format": "beancount",
@@ -126,10 +151,13 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["directive", "price"]
+      "tags": [
+        "directive",
+        "price"
+      ]
     },
     {
-      "id": "commodity-format",
+      "id": "commodity-format-b2h",
       "description": "Commodity format is preserved",
       "source": {
         "format": "beancount",
@@ -141,7 +169,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["commodity", "format"]
+      "tags": [
+        "commodity",
+        "format"
+      ]
     },
     {
       "id": "booking-method-lost",
@@ -155,9 +186,14 @@
       },
       "expected": {
         "convert": "success",
-        "warnings": ["booking method"]
+        "warnings": [
+          "booking method"
+        ]
       },
-      "tags": ["booking", "loss"]
+      "tags": [
+        "booking",
+        "loss"
+      ]
     }
   ]
 }

--- a/tests/cross-format/beancount-to-ledger/tests.json
+++ b/tests/cross-format/beancount-to-ledger/tests.json
@@ -4,7 +4,7 @@
   "description": "Beancount to Ledger format conversion tests",
   "tests": [
     {
-      "id": "simple-transaction",
+      "id": "simple-transaction-b2l",
       "description": "Basic transaction converts correctly",
       "source": {
         "format": "beancount",
@@ -16,11 +16,18 @@
       "expected": {
         "convert": "success",
         "balance": {
-          "Expenses:Food": {"USD": "50.00"},
-          "Assets:Checking": {"USD": "-50.00"}
+          "Expenses:Food": {
+            "USD": "50.00"
+          },
+          "Assets:Checking": {
+            "USD": "-50.00"
+          }
         }
       },
-      "tags": ["transaction", "basic"]
+      "tags": [
+        "transaction",
+        "basic"
+      ]
     },
     {
       "id": "open-to-account",
@@ -35,10 +42,13 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["directive", "account"]
+      "tags": [
+        "directive",
+        "account"
+      ]
     },
     {
-      "id": "transaction-with-tags",
+      "id": "transaction-with-tags-b2l",
       "description": "Tags convert to Ledger metadata",
       "source": {
         "format": "beancount",
@@ -50,7 +60,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["tags", "metadata"]
+      "tags": [
+        "tags",
+        "metadata"
+      ]
     },
     {
       "id": "transaction-with-links",
@@ -65,10 +78,13 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["links", "metadata"]
+      "tags": [
+        "links",
+        "metadata"
+      ]
     },
     {
-      "id": "balance-assertion",
+      "id": "balance-assertion-b2l",
       "description": "Balance assertion converts",
       "source": {
         "format": "beancount",
@@ -80,7 +96,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["balance", "assertion"]
+      "tags": [
+        "balance",
+        "assertion"
+      ]
     },
     {
       "id": "commodity-directive",
@@ -95,10 +114,13 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["directive", "commodity"]
+      "tags": [
+        "directive",
+        "commodity"
+      ]
     },
     {
-      "id": "price-directive",
+      "id": "price-directive-b2l",
       "description": "Price directive converts",
       "source": {
         "format": "beancount",
@@ -110,7 +132,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["directive", "price"]
+      "tags": [
+        "directive",
+        "price"
+      ]
     },
     {
       "id": "lot-with-cost",
@@ -125,13 +150,18 @@
       "expected": {
         "convert": "success",
         "balance": {
-          "Assets:Brokerage": {"AAPL": "10"}
+          "Assets:Brokerage": {
+            "AAPL": "10"
+          }
         }
       },
-      "tags": ["lot", "cost"]
+      "tags": [
+        "lot",
+        "cost"
+      ]
     },
     {
-      "id": "lot-with-price",
+      "id": "lot-with-price-b2l",
       "description": "Lot with price annotation converts",
       "source": {
         "format": "beancount",
@@ -143,7 +173,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["lot", "price"]
+      "tags": [
+        "lot",
+        "price"
+      ]
     },
     {
       "id": "multi-currency",
@@ -158,7 +191,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["currency", "exchange"]
+      "tags": [
+        "currency",
+        "exchange"
+      ]
     },
     {
       "id": "posting-metadata",
@@ -173,7 +209,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["metadata", "posting"]
+      "tags": [
+        "metadata",
+        "posting"
+      ]
     },
     {
       "id": "pad-directive",
@@ -188,7 +227,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["directive", "pad"],
+      "tags": [
+        "directive",
+        "pad"
+      ],
       "skip": true,
       "skip_reason": "Pad has no direct Ledger equivalent"
     },
@@ -205,7 +247,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["directive", "note"]
+      "tags": [
+        "directive",
+        "note"
+      ]
     },
     {
       "id": "event-directive",
@@ -220,7 +265,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["directive", "event"]
+      "tags": [
+        "directive",
+        "event"
+      ]
     },
     {
       "id": "incomplete-flag",
@@ -235,7 +283,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["flag", "pending"]
+      "tags": [
+        "flag",
+        "pending"
+      ]
     }
   ]
 }

--- a/tests/cross-format/hledger-to-beancount/tests.json
+++ b/tests/cross-format/hledger-to-beancount/tests.json
@@ -4,7 +4,7 @@
   "description": "hledger to Beancount format conversion tests",
   "tests": [
     {
-      "id": "simple-transaction",
+      "id": "simple-transaction-h2b",
       "description": "Basic transaction converts correctly",
       "source": {
         "format": "hledger",
@@ -16,10 +16,15 @@
       "expected": {
         "convert": "success",
         "balance": {
-          "Expenses:Food": {"USD": "50.00"}
+          "Expenses:Food": {
+            "USD": "50.00"
+          }
         }
       },
-      "tags": ["transaction", "basic"]
+      "tags": [
+        "transaction",
+        "basic"
+      ]
     },
     {
       "id": "account-case-converted",
@@ -33,12 +38,18 @@
       },
       "expected": {
         "convert": "success",
-        "accounts": ["Expenses:Food:Groceries", "Assets:Bank:Checking"]
+        "accounts": [
+          "Expenses:Food:Groceries",
+          "Assets:Bank:Checking"
+        ]
       },
-      "tags": ["account", "case"]
+      "tags": [
+        "account",
+        "case"
+      ]
     },
     {
-      "id": "virtual-posting-lost",
+      "id": "virtual-posting-lost-h2b",
       "description": "Virtual postings are lost (warning)",
       "source": {
         "format": "hledger",
@@ -49,12 +60,17 @@
       },
       "expected": {
         "convert": "success",
-        "warnings": ["virtual"]
+        "warnings": [
+          "virtual"
+        ]
       },
-      "tags": ["virtual", "loss"]
+      "tags": [
+        "virtual",
+        "loss"
+      ]
     },
     {
-      "id": "periodic-lost",
+      "id": "periodic-lost-h2b",
       "description": "Periodic transactions cannot convert",
       "source": {
         "format": "hledger",
@@ -65,9 +81,14 @@
       },
       "expected": {
         "convert": "success",
-        "warnings": ["periodic"]
+        "warnings": [
+          "periodic"
+        ]
       },
-      "tags": ["periodic", "loss"]
+      "tags": [
+        "periodic",
+        "loss"
+      ]
     },
     {
       "id": "auto-lost",
@@ -81,12 +102,17 @@
       },
       "expected": {
         "convert": "success",
-        "warnings": ["auto"]
+        "warnings": [
+          "auto"
+        ]
       },
-      "tags": ["auto", "loss"]
+      "tags": [
+        "auto",
+        "loss"
+      ]
     },
     {
-      "id": "commodity-symbol-converted",
+      "id": "commodity-symbol-converted-h2b",
       "description": "Commodity symbols converted to codes",
       "source": {
         "format": "hledger",
@@ -98,7 +124,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["commodity", "symbol"]
+      "tags": [
+        "commodity",
+        "symbol"
+      ]
     },
     {
       "id": "open-directives-generated",
@@ -114,10 +143,13 @@
         "convert": "success",
         "directives": 3
       },
-      "tags": ["account", "open"]
+      "tags": [
+        "account",
+        "open"
+      ]
     },
     {
-      "id": "balance-assertion",
+      "id": "balance-assertion-h2b",
       "description": "Balance assertion converts",
       "source": {
         "format": "hledger",
@@ -129,7 +161,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["balance", "assertion"]
+      "tags": [
+        "balance",
+        "assertion"
+      ]
     },
     {
       "id": "balance-assignment-converted",
@@ -144,7 +179,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["balance", "assignment"]
+      "tags": [
+        "balance",
+        "assignment"
+      ]
     },
     {
       "id": "tags-converted",
@@ -159,7 +197,9 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["tags"]
+      "tags": [
+        "tags"
+      ]
     }
   ]
 }

--- a/tests/cross-format/hledger-to-ledger/tests.json
+++ b/tests/cross-format/hledger-to-ledger/tests.json
@@ -4,7 +4,7 @@
   "description": "hledger to Ledger format conversion tests",
   "tests": [
     {
-      "id": "simple-transaction",
+      "id": "simple-transaction-h2l",
       "description": "Basic transaction converts with high fidelity",
       "source": {
         "format": "hledger",
@@ -16,7 +16,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["transaction", "basic"]
+      "tags": [
+        "transaction",
+        "basic"
+      ]
     },
     {
       "id": "account-case-preserved",
@@ -31,10 +34,13 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["account", "case"]
+      "tags": [
+        "account",
+        "case"
+      ]
     },
     {
-      "id": "virtual-posting",
+      "id": "virtual-posting-h2l",
       "description": "Virtual postings convert directly",
       "source": {
         "format": "hledger",
@@ -46,10 +52,12 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["virtual"]
+      "tags": [
+        "virtual"
+      ]
     },
     {
-      "id": "periodic-transaction",
+      "id": "periodic-transaction-h2l",
       "description": "Periodic transaction converts",
       "source": {
         "format": "hledger",
@@ -61,7 +69,9 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["periodic"]
+      "tags": [
+        "periodic"
+      ]
     },
     {
       "id": "auto-posting",
@@ -76,7 +86,9 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["auto"]
+      "tags": [
+        "auto"
+      ]
     },
     {
       "id": "balance-assignment",
@@ -91,7 +103,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["balance", "assignment"]
+      "tags": [
+        "balance",
+        "assignment"
+      ]
     },
     {
       "id": "subaccount-assertion",
@@ -106,7 +121,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["balance", "assertion"],
+      "tags": [
+        "balance",
+        "assertion"
+      ],
       "skip": true,
       "skip_reason": "Ledger doesn't have subaccount assertions"
     },
@@ -123,7 +141,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["date", "format"]
+      "tags": [
+        "date",
+        "format"
+      ]
     },
     {
       "id": "tags",
@@ -138,7 +159,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["tags", "metadata"]
+      "tags": [
+        "tags",
+        "metadata"
+      ]
     },
     {
       "id": "decimal-mark",
@@ -153,7 +177,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["decimal", "format"]
+      "tags": [
+        "decimal",
+        "format"
+      ]
     }
   ]
 }

--- a/tests/cross-format/ledger-to-beancount/tests.json
+++ b/tests/cross-format/ledger-to-beancount/tests.json
@@ -4,7 +4,7 @@
   "description": "Ledger to Beancount format conversion tests",
   "tests": [
     {
-      "id": "simple-transaction",
+      "id": "simple-transaction-l2b",
       "description": "Basic transaction converts correctly",
       "source": {
         "format": "ledger",
@@ -16,13 +16,18 @@
       "expected": {
         "convert": "success",
         "balance": {
-          "Expenses:Food": {"USD": "50.00"}
+          "Expenses:Food": {
+            "USD": "50.00"
+          }
         }
       },
-      "tags": ["transaction", "basic"]
+      "tags": [
+        "transaction",
+        "basic"
+      ]
     },
     {
-      "id": "virtual-posting-lost",
+      "id": "virtual-posting-lost-l2b",
       "description": "Virtual postings are lost (warning)",
       "source": {
         "format": "ledger",
@@ -33,12 +38,17 @@
       },
       "expected": {
         "convert": "success",
-        "warnings": ["virtual"]
+        "warnings": [
+          "virtual"
+        ]
       },
-      "tags": ["virtual", "loss"]
+      "tags": [
+        "virtual",
+        "loss"
+      ]
     },
     {
-      "id": "commodity-symbol-converted",
+      "id": "commodity-symbol-converted-l2b",
       "description": "Commodity symbols converted to codes",
       "source": {
         "format": "ledger",
@@ -50,10 +60,15 @@
       "expected": {
         "convert": "success",
         "balance": {
-          "Expenses:Food": {"USD": "50.00"}
+          "Expenses:Food": {
+            "USD": "50.00"
+          }
         }
       },
-      "tags": ["commodity", "symbol"]
+      "tags": [
+        "commodity",
+        "symbol"
+      ]
     },
     {
       "id": "needs-open-directives",
@@ -67,9 +82,15 @@
       },
       "expected": {
         "convert": "success",
-        "accounts": ["Expenses:Food", "Assets:Checking"]
+        "accounts": [
+          "Expenses:Food",
+          "Assets:Checking"
+        ]
       },
-      "tags": ["account", "open"]
+      "tags": [
+        "account",
+        "open"
+      ]
     },
     {
       "id": "expression-evaluated",
@@ -84,10 +105,14 @@
       "expected": {
         "convert": "success",
         "balance": {
-          "Expenses:Food": {"USD": "50.00"}
+          "Expenses:Food": {
+            "USD": "50.00"
+          }
         }
       },
-      "tags": ["expression"]
+      "tags": [
+        "expression"
+      ]
     },
     {
       "id": "automated-lost",
@@ -101,12 +126,17 @@
       },
       "expected": {
         "convert": "success",
-        "warnings": ["automated"]
+        "warnings": [
+          "automated"
+        ]
       },
-      "tags": ["automated", "loss"]
+      "tags": [
+        "automated",
+        "loss"
+      ]
     },
     {
-      "id": "periodic-lost",
+      "id": "periodic-lost-l2b",
       "description": "Periodic transactions cannot convert",
       "source": {
         "format": "ledger",
@@ -117,9 +147,14 @@
       },
       "expected": {
         "convert": "success",
-        "warnings": ["periodic"]
+        "warnings": [
+          "periodic"
+        ]
       },
-      "tags": ["periodic", "loss"]
+      "tags": [
+        "periodic",
+        "loss"
+      ]
     },
     {
       "id": "date-format-converted",
@@ -134,10 +169,13 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["date", "format"]
+      "tags": [
+        "date",
+        "format"
+      ]
     },
     {
-      "id": "balance-assertion",
+      "id": "balance-assertion-l2b",
       "description": "Balance assertion converts",
       "source": {
         "format": "ledger",
@@ -149,7 +187,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["balance", "assertion"]
+      "tags": [
+        "balance",
+        "assertion"
+      ]
     },
     {
       "id": "lot-cost",
@@ -164,7 +205,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["lot", "cost"]
+      "tags": [
+        "lot",
+        "cost"
+      ]
     }
   ]
 }

--- a/tests/cross-format/ledger-to-hledger/tests.json
+++ b/tests/cross-format/ledger-to-hledger/tests.json
@@ -4,7 +4,7 @@
   "description": "Ledger to hledger format conversion tests",
   "tests": [
     {
-      "id": "simple-transaction",
+      "id": "simple-transaction-l2h",
       "description": "Basic transaction converts with high fidelity",
       "source": {
         "format": "ledger",
@@ -16,13 +16,18 @@
       "expected": {
         "convert": "success",
         "balance": {
-          "Expenses:Food": {"USD": "50.00"}
+          "Expenses:Food": {
+            "USD": "50.00"
+          }
         }
       },
-      "tags": ["transaction", "basic"]
+      "tags": [
+        "transaction",
+        "basic"
+      ]
     },
     {
-      "id": "virtual-posting",
+      "id": "virtual-posting-l2h",
       "description": "Virtual postings convert directly",
       "source": {
         "format": "ledger",
@@ -34,7 +39,9 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["virtual"]
+      "tags": [
+        "virtual"
+      ]
     },
     {
       "id": "balanced-virtual",
@@ -49,10 +56,13 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["virtual", "balanced"]
+      "tags": [
+        "virtual",
+        "balanced"
+      ]
     },
     {
-      "id": "periodic-transaction",
+      "id": "periodic-transaction-l2h",
       "description": "Periodic transaction converts",
       "source": {
         "format": "ledger",
@@ -64,7 +74,9 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["periodic"]
+      "tags": [
+        "periodic"
+      ]
     },
     {
       "id": "automated-transaction",
@@ -79,7 +91,9 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["automated"]
+      "tags": [
+        "automated"
+      ]
     },
     {
       "id": "account-directive",
@@ -94,10 +108,13 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["directive", "account"]
+      "tags": [
+        "directive",
+        "account"
+      ]
     },
     {
-      "id": "commodity-format",
+      "id": "commodity-format-l2h",
       "description": "Commodity format converts",
       "source": {
         "format": "ledger",
@@ -109,10 +126,13 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["directive", "commodity"]
+      "tags": [
+        "directive",
+        "commodity"
+      ]
     },
     {
-      "id": "balance-assertion",
+      "id": "balance-assertion-l2h",
       "description": "Balance assertion converts directly",
       "source": {
         "format": "ledger",
@@ -124,7 +144,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["balance", "assertion"]
+      "tags": [
+        "balance",
+        "assertion"
+      ]
     },
     {
       "id": "lot-price",
@@ -139,7 +162,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["lot", "price"]
+      "tags": [
+        "lot",
+        "price"
+      ]
     },
     {
       "id": "metadata-tags",
@@ -154,7 +180,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["metadata", "tags"]
+      "tags": [
+        "metadata",
+        "tags"
+      ]
     },
     {
       "id": "expression-amount-lost",
@@ -169,10 +198,15 @@
       "expected": {
         "convert": "success",
         "balance": {
-          "Expenses:Food": {"USD": "50.00"}
+          "Expenses:Food": {
+            "USD": "50.00"
+          }
         }
       },
-      "tags": ["expression", "evaluation"]
+      "tags": [
+        "expression",
+        "evaluation"
+      ]
     },
     {
       "id": "effective-date",
@@ -187,7 +221,10 @@
       "expected": {
         "convert": "success"
       },
-      "tags": ["date", "effective"]
+      "tags": [
+        "date",
+        "effective"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Problem

30 test IDs were duplicated across files within the same test manifest, causing tests to shadow each other in the results map. This made conformance reports confusing — e.g., `unicode-account-name` appeared in both `syntax/edge-cases` (Japanese, expects parse=error) and `regression` (French, expects parse=success), and the result reporter mixed them up.

## Fix

Renamed all duplicates within each manifest scope by adding a suite suffix:

| Suite | Suffix |
|---|---|
| `syntax/valid` | `-valid` |
| `syntax/edge-cases` | `-edge` |
| `booking` | `-booking` |
| `regression` | `-regression` |
| `beancount-to-ledger` | `-b2l` |
| `beancount-to-hledger` | `-b2h` |
| `ledger-to-hledger` | `-l2h` |
| `ledger-to-beancount` | `-l2b` |
| `hledger-to-ledger` | `-h2l` |
| `hledger-to-beancount` | `-h2b` |

19 IDs renamed in beancount v3 (+ all instances in each), 11 in cross-format.

## Prevention

Added `scripts/check_test_ids_unique.py` and wired it into the `validate-test-schemas` CI job. Any future PR that introduces a duplicate within a manifest will fail CI.

## Note

Line counts are inflated because `json.dump()` reformatted the files. Actual test content is unchanged except for the ID renames.

## Test plan

- [ ] CI passes including the new uniqueness check
- [ ] Beancount conformance unchanged at 264/0
- [ ] Rustledger conformance unchanged at ~255/9 (no test logic changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)