### PR TITLE
fix(harness): classify rustledger errors by phase field, not code prefix

### DIFF
--- a/tests/harness/runners/python/executors/rustledger.py
+++ b/tests/harness/runners/python/executors/rustledger.py
@@ -146,11 +146,24 @@ class RustledgerExecutor(BaseExecutor):
             _success, errors, _raw = self._run_check(file_path)
             duration_ms = (time.perf_counter() - start_time) * 1000
 
-            # Separate parse errors from validation errors using error codes.
-            # rustledger uses P-prefixed codes for parse errors (e.g., P0012)
-            # and E-prefixed codes for validation errors (e.g., E1001, E3001).
-            parse_errors = [e for e in errors if str(e.get("code", "")).startswith("P")]
-            validation_errors = [e for e in errors if not str(e.get("code", "")).startswith("P")]
+            # Separate parse errors from validation errors using the `phase` field.
+            # rustledger tags each diagnostic with "parse" or "validate" based on when
+            # it was detected (lex/parse/load vs. semantic validation). This is more
+            # accurate than classifying by code prefix alone — for example, E7001
+            # (unknown option) fires during the load phase and is correctly tagged
+            # phase="parse" even though its code starts with E.
+            #
+            # Fall back to the legacy code-prefix heuristic (P* = parse) for older
+            # rustledger builds that don't emit the `phase` field, so the runner
+            # remains backwards compatible.
+            def _is_parse_error(e: dict) -> bool:
+                phase = e.get("phase")
+                if phase is not None:
+                    return phase == "parse"
+                return str(e.get("code", "")).startswith("P")
+
+            parse_errors = [e for e in errors if _is_parse_error(e)]
+            validation_errors = [e for e in errors if not _is_parse_error(e)]
 
             # Check parse result
             parse_succeeded = len(parse_errors) == 0

--- a/tests/harness/runners/python/executors/rustledger.py
+++ b/tests/harness/runners/python/executors/rustledger.py
@@ -159,8 +159,8 @@ class RustledgerExecutor(BaseExecutor):
             def _is_parse_error(e: dict) -> bool:
                 phase = e.get("phase")
                 if phase is not None:
-                    return phase == "parse"
-                return str(e.get("code", "")).startswith("P")
+                    return bool(phase == "parse")
+                return bool(str(e.get("code", "")).startswith("P"))
 
             parse_errors = [e for e in errors if _is_parse_error(e)]
             validation_errors = [e for e in errors if not _is_parse_error(e)]


### PR DESCRIPTION
## Summary

The rustledger executor currently classifies errors as parse vs validate by checking whether the error code starts with `P`. This misclassifies diagnostics that rustledger detects during the parse/load phase but tags with an `E`-prefixed code — most notably `E7001` (unknown option), which rustledger fires during loading and already tags with `phase="parse"` in its JSON output.

Switch the classification to use the `phase` field with a code-prefix fallback for backwards compatibility with older rustledger builds that don't emit `phase`.

## Context

This was surfaced while reviewing rustledger/rustledger#736, which claims the parser still accepts 5 invalid inputs after PRs #708 and #726. Investigation against rustledger `d00d001`:

| Test | Diagnostic | Before this PR | After this PR |
|---|---|---|---|
| `invalid-balance-no-amount` | `P0012` phase=parse | ✅ passes | ✅ passes |
| `invalid-pad-no-source` | `P0012` phase=parse | ✅ passes | ✅ passes |
| `invalid-option-unknown` | `E7001` phase=parse | ❌ fails (misclassified) | ✅ **passes** |
| `invalid-account-root` | `E1005` phase=validate | ❌ fails | ❌ still fails* |
| `invalid-cost-unclosed` | `E3001` phase=validate | ❌ fails | ❌ still fails* |

*These two remain failing and are tracked as follow-up work in rustledger itself:
- `invalid-account-root`: rustledger fires this during the validate phase. Needs to either move the check to the load phase or add a parser-level check after options are resolved.
- `invalid-cost-unclosed`: genuine regression in the parser — the unclosed `{…` is silently accepted when there's a currency token inside the block. The unit test added in rustledger PR #726 doesn't catch this input shape.

## Test plan

- [x] Classification logic verified in isolation — `E7001 phase=parse` → parse error; `E1005 phase=validate` → validate error; legacy builds without `phase` fall back to code-prefix.
- [ ] Conformance workflow run against rustledger `d00d001` to confirm `invalid-option-unknown` flips to pass.
- [ ] Confirm no other tests change status as a side effect.

Refs rustledger/rustledger#736

🤖 Generated with [Claude Code](https://claude.com/claude-code)