### PR TITLE
fix(harness): append trailing newline when writing inline test content

### DIFF
--- a/tests/harness/runners/python/executors/bql.py
+++ b/tests/harness/runners/python/executors/bql.py
@@ -44,6 +44,8 @@ class BQLExecutor(BaseExecutor):
                 dsn = f"beancount://{abs_path}"
             elif test.input.inline is not None:
                 content = test.input.inline
+                if not content.endswith("\n"):
+                    content += "\n"
                 with tempfile.NamedTemporaryFile(mode="w", suffix=".beancount", delete=False) as f:
                     f.write(content)
                     temp_path = f.name

--- a/tests/harness/runners/python/executors/rustledger.py
+++ b/tests/harness/runners/python/executors/rustledger.py
@@ -110,6 +110,11 @@ class RustledgerExecutor(BaseExecutor):
             # Get input content and write to temp file
             if test.input.inline is not None:
                 content = test.input.inline
+                # Ensure the content ends with a newline. POSIX convention is
+                # that text files end with \n, and some parsers only recognize
+                # the end of a directive when followed by a newline/EOF boundary.
+                if not content.endswith("\n"):
+                    content += "\n"
                 with tempfile.NamedTemporaryFile(mode="w", suffix=".beancount", delete=False) as f:
                     f.write(content)
                     temp_path = f.name

--- a/tests/harness/runners/python/executors/syntax.py
+++ b/tests/harness/runners/python/executors/syntax.py
@@ -28,6 +28,8 @@ class SyntaxExecutor(BaseExecutor):
             # Get input content
             if test.input.inline is not None:
                 content = test.input.inline
+                if not content.endswith("\n"):
+                    content += "\n"
                 # Write to temp file for beancount loader
                 with tempfile.NamedTemporaryFile(mode="w", suffix=".beancount", delete=False) as f:
                     f.write(content)

--- a/tests/harness/runners/python/executors/validation.py
+++ b/tests/harness/runners/python/executors/validation.py
@@ -28,6 +28,8 @@ class ValidationExecutor(BaseExecutor):
             # Get input content
             if test.input.inline is not None:
                 content = test.input.inline
+                if not content.endswith("\n"):
+                    content += "\n"
                 with tempfile.NamedTemporaryFile(mode="w", suffix=".beancount", delete=False) as f:
                     f.write(content)
                     temp_path = f.name


### PR DESCRIPTION
## Problem

Some parsers (including rustledger) only detect directive termination at a newline boundary. When inline test content has no trailing newline, the parser may silently accept otherwise-invalid input because it reads to EOF still in "parsing directive" state.

Example from rustledger d00d001 (latest main):

```bash
$ printf '2024-01-01 open Assets:Checking\n\n2024-01-15 balance Assets:Checking' > test.bean
$ rledger check --format json test.bean
{"diagnostics":[],"error_count":0,...}  ← silently accepted

$ printf '2024-01-01 open Assets:Checking\n\n2024-01-15 balance Assets:Checking\n' > test.bean
$ rledger check --format json test.bean
{"diagnostics":[{"code":"P0012","message":"parse error: unexpected input"}],...}
```

This explains why `invalid-balance-no-amount` and `invalid-pad-no-source` appeared to fail in our conformance runs but passed in rustledger/rustledger#736's manual verification — the reviewer added a trailing newline when writing their test files.

## Fix

The harness now normalizes inline content by appending `\n` if not present, matching POSIX file conventions. This affects all three executors (syntax, validation, rustledger) plus BQL.

I'll still file a follow-up rustledger issue because silently accepting unterminated directives at EOF is a parser bug regardless of file convention — beancount handles both cases.

## Related

- rustledger/rustledger#736 comment by @robcohen explaining cases 2 and 3 are false alarms
- rustledger/pta-standards#30 for the phase-field classification fix (handles case 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)