### PR TITLE
feat: unskip document-directive and include-cycle-detection tests

### DIFF
--- a/tests/beancount/v3/syntax/valid/fixtures/document-directive.beancount
+++ b/tests/beancount/v3/syntax/valid/fixtures/document-directive.beancount
@@ -1,0 +1,3 @@
+2024-01-01 open Assets:Checking
+
+2024-01-15 document Assets:Checking "statement.pdf"

--- a/tests/beancount/v3/syntax/valid/tests.json
+++ b/tests/beancount/v3/syntax/valid/tests.json
@@ -381,10 +381,8 @@
     {
       "id": "document-directive",
       "description": "Document directive",
-      "skip": true,
-      "skip_reason": "Document validation checks file existence during load - requires test fixture file",
       "input": {
-        "inline": "2024-01-01 open Assets:Checking\n\n2024-01-15 document Assets:Checking \"statement.pdf\""
+        "file": "fixtures/document-directive.beancount"
       },
       "expected": {
         "parse": "success"

--- a/tests/beancount/v3/validation/fixtures/cycle-a.beancount
+++ b/tests/beancount/v3/validation/fixtures/cycle-a.beancount
@@ -1,0 +1,5 @@
+; Circular include test file A
+; Includes cycle-b which includes this file back
+include "cycle-b.beancount"
+
+2024-01-01 open Assets:A USD

--- a/tests/beancount/v3/validation/fixtures/cycle-b.beancount
+++ b/tests/beancount/v3/validation/fixtures/cycle-b.beancount
@@ -1,0 +1,5 @@
+; Circular include test file B
+; Includes cycle-a which already includes this file
+include "cycle-a.beancount"
+
+2024-01-01 open Assets:B USD

--- a/tests/beancount/v3/validation/tests.json
+++ b/tests/beancount/v3/validation/tests.json
@@ -252,13 +252,11 @@
     },
     {
       "id": "include-cycle-detection",
-      "description": "Circular include is detected",
-      "skip": true,
-      "skip_reason": "Requires external file setup",
+      "description": "Circular include is detected as duplicate filename",
       "input": {"file": "fixtures/cycle-a.beancount"},
       "expected": {
         "parse": "error",
-        "error_contains": ["Circular"]
+        "error_contains": ["Duplicate filename"]
       },
       "tags": ["include", "cycle"]
     }


### PR DESCRIPTION
## Summary

Two tests were skipped with `Requires external file setup` / `requires test fixture file`. Both just needed fixture files alongside the test — no harness changes needed.

### 1. `document-directive`
Beancount validates that the file path in a `document` directive exists relative to the containing file. Switched from inline input to `fixtures/document-directive.beancount` + placeholder `statement.pdf` in the same directory so the loader can resolve it.

### 2. `include-cycle-detection`
Added `fixtures/cycle-a.beancount` and `fixtures/cycle-b.beancount` that include each other. Also fixed the expected error message — beancount emits `"Duplicate filename parsed"` when it detects a cycle via its `filenames_seen` set, not `"Circular"`.

## Impact

- Beancount: 264 passed, 0 failed, **15 skipped** (down from 17)
- Rustledger: 264 passed, 0 failed (unchanged — still 100% conformance)

The remaining 15 skipped tests are legitimately unfixable without spec changes or upstream work (beanquery missing features, beancount 3.x unimplemented features, spec ambiguities).

🤖 Generated with [Claude Code](https://claude.com/claude-code)