### PR TITLE
fix: use .txt instead of .pdf for document fixture

### DIFF
--- a/tests/beancount/v3/syntax/valid/fixtures/document-directive.beancount
+++ b/tests/beancount/v3/syntax/valid/fixtures/document-directive.beancount
@@ -1,3 +1,3 @@
 2024-01-01 open Assets:Checking
 
-2024-01-15 document Assets:Checking "statement.pdf"
+2024-01-15 document Assets:Checking "statement.txt"

--- a/tests/beancount/v3/syntax/valid/fixtures/statement.txt
+++ b/tests/beancount/v3/syntax/valid/fixtures/statement.txt
@@ -1,0 +1,1 @@
+statement placeholder


### PR DESCRIPTION
## Problem

PR #32 added `statement.pdf` as a document fixture, but `.gitignore` excludes `*.pdf` (originally intended for build output). The file never made it into the repo, so beancount's `document` directive validation failed with `File does not exist`.

## Fix

Use `statement.txt` instead — beancount's document directive just checks file existence, the extension doesn't matter.

Also filed rustledger/rustledger#765 for the circular include error wording mismatch (rustledger says "include cycle detected", beancount says "Duplicate filename parsed").

🤖 Generated with [Claude Code](https://claude.com/claude-code)