### PR TITLE
feat: per-implementation skip support

### DIFF
--- a/tests/beancount/v3/bql/tests.json
+++ b/tests/beancount/v3/bql/tests.json
@@ -947,8 +947,9 @@
       "id": "bql-weight-function",
       "description": "WEIGHT function returns position weight",
       "spec_ref": "bql/functions.md#weight",
-      "skip": true,
-      "skip_reason": "weight function not available in beanquery",
+      "skip_implementations": {
+        "beancount": "weight function not available in beanquery"
+      },
       "input": {
         "file": "fixtures/with-costs.beancount",
         "query": "SELECT account, weight(position) FROM postings"

--- a/tests/harness/runners/python/loader.py
+++ b/tests/harness/runners/python/loader.py
@@ -62,6 +62,7 @@ class TestCase:
     tags: list[str] = field(default_factory=list)
     skip: bool = False
     skip_reason: str | None = None
+    skip_implementations: dict[str, str] = field(default_factory=dict)
     suite: str = ""
 
     def get_test_type(self) -> str:
@@ -71,6 +72,14 @@ class TestCase:
         if self.expected.validate is not None:
             return "validation"
         return "syntax"
+
+    def should_skip(self, implementation: str) -> tuple[bool, str | None]:
+        """Return (skip, reason) for the given implementation."""
+        if self.skip:
+            return True, self.skip_reason
+        if implementation in self.skip_implementations:
+            return True, self.skip_implementations[implementation]
+        return False, None
 
 
 @dataclass
@@ -143,6 +152,7 @@ def load_test_suite(path: Path) -> list[TestCase]:
             tags=test_data.get("tags", []),
             skip=test_data.get("skip", False),
             skip_reason=test_data.get("skip_reason"),
+            skip_implementations=test_data.get("skip_implementations", {}),
             suite=suite_name,
         )
         tests.append(test_case)

--- a/tests/harness/runners/python/runner.py
+++ b/tests/harness/runners/python/runner.py
@@ -50,6 +50,14 @@ def run_tests(
     results = []
 
     for test in tests:
+        # Check per-implementation skip. We mutate test.skip/skip_reason so
+        # the existing executor skip check picks it up. This is scoped to
+        # the current run and isn't persisted.
+        skip, reason = test.should_skip(_implementation)
+        if skip and not test.skip:
+            test.skip = True
+            test.skip_reason = reason
+
         executor = get_executor(test)
         result = executor.execute(test)
         results.append(result)

--- a/tests/harness/runners/python/tests/test_loader.py
+++ b/tests/harness/runners/python/tests/test_loader.py
@@ -114,6 +114,41 @@ class TestTestCase:
         )
         assert tc.get_test_type() == "bql"
 
+    def test_should_skip_global(self):
+        tc = TestCase(
+            id="t",
+            description="d",
+            input=TestInput(inline="x"),
+            expected=TestExpected(),
+            base_path=Path("."),
+            skip=True,
+            skip_reason="global skip",
+        )
+        assert tc.should_skip("beancount") == (True, "global skip")
+        assert tc.should_skip("rustledger") == (True, "global skip")
+
+    def test_should_skip_per_implementation(self):
+        tc = TestCase(
+            id="t",
+            description="d",
+            input=TestInput(inline="x"),
+            expected=TestExpected(),
+            base_path=Path("."),
+            skip_implementations={"beancount": "missing feature"},
+        )
+        assert tc.should_skip("beancount") == (True, "missing feature")
+        assert tc.should_skip("rustledger") == (False, None)
+
+    def test_should_skip_none(self):
+        tc = TestCase(
+            id="t",
+            description="d",
+            input=TestInput(inline="x"),
+            expected=TestExpected(),
+            base_path=Path("."),
+        )
+        assert tc.should_skip("beancount") == (False, None)
+
 
 class TestLoadManifest:
     def test_load_manifest(self, tmp_manifest: Path):

--- a/tests/harness/test-case.schema.json
+++ b/tests/harness/test-case.schema.json
@@ -93,11 +93,16 @@
     },
     "skip": {
       "type": "boolean",
-      "description": "Whether to skip this test"
+      "description": "Whether to skip this test for all implementations"
     },
     "skip_reason": {
       "type": "string",
       "description": "Reason for skipping (if skip is true)"
+    },
+    "skip_implementations": {
+      "type": "object",
+      "description": "Per-implementation skip reasons, keyed by implementation name (e.g., 'beancount', 'rustledger')",
+      "additionalProperties": {"type": "string"}
     },
     "source": {
       "type": "object",


### PR DESCRIPTION
## Summary

Adds `skip_implementations` field to the test-case schema so tests can be skipped for specific implementations without blocking others. This resolves a harness limitation where `skip: true` was global — a test testing a feature missing in beanquery but supported in rustledger had to be globally skipped, losing coverage for the implementation that does support it.

## Changes

- **Schema** (`tests/harness/test-case.schema.json`): new optional `skip_implementations` object keyed by implementation name
- **Loader** (`loader.py`): parses the field and adds `TestCase.should_skip(impl)` method
- **Runner** (`runner.py`): applies per-implementation skip before dispatching to the executor
- **Unit tests**: cover global skip, per-implementation skip, and no-skip cases

## First use: `bql-weight-function`

`WEIGHT()` is supported by rustledger's BQL but not by beanquery. With this PR:
- Beancount run: test is skipped with reason "weight function not available in beanquery"
- Rustledger run: test executes normally

This recovers 1 test's worth of rustledger coverage.

## Future use

Several other skipped BQL tests check for features that may be supported in one implementation but not the other (e.g., `CASE`, `LIKE`, `SUBACCOUNT`). Each can now be unskipped selectively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)