### PR TITLE
refactor: base conformance suite on the spec, not on reference implementations

### DIFF
--- a/tests/beancount/v3/booking/tests.json
+++ b/tests/beancount/v3/booking/tests.json
@@ -107,8 +107,6 @@
       "id": "booking-average-cost",
       "description": "AVERAGE booking uses weighted average cost",
       "spec_ref": "booking.md#average-cost",
-      "skip": true,
-      "skip_reason": "AVERAGE booking method not implemented in Python beancount 3.x",
       "input": {
         "inline": "2024-01-01 open Assets:Stock AAPL \"AVERAGE\"\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy lot 1 at 100\"\n  Assets:Stock 10 AAPL {100 USD}\n  Assets:Cash -1000 USD\n\n2024-01-20 * \"Buy lot 2 at 200\"\n  Assets:Stock 10 AAPL {200 USD}\n  Assets:Cash -2000 USD\n\n2024-02-15 * \"Sell at average (150)\"\n  Assets:Stock -5 AAPL {}\n  Assets:Cash 800 USD\n  Income:Gains"
       },
@@ -260,8 +258,6 @@
       "id": "cost-asterisk-merge",
       "description": "Asterisk * in cost merges all lots",
       "spec_ref": "costs.md#cost-merge",
-      "skip": true,
-      "skip_reason": "Cost merging {*} not implemented in Python beancount 3.x",
       "input": {
         "inline": "2024-01-01 open Assets:Stock AAPL\n2024-01-01 open Assets:Cash USD\n2024-01-01 open Income:Gains\n\n2024-01-15 * \"Buy lot 1\"\n  Assets:Stock 10 AAPL {150 USD}\n  Assets:Cash -1500 USD\n\n2024-01-20 * \"Buy lot 2\"\n  Assets:Stock 10 AAPL {160 USD}\n  Assets:Cash -1600 USD\n\n2024-02-15 * \"Sell with merge\"\n  Assets:Stock -5 AAPL {*}\n  Assets:Cash 800 USD\n  Income:Gains"
       },

--- a/tests/beancount/v3/bql/tests.json
+++ b/tests/beancount/v3/bql/tests.json
@@ -15,7 +15,10 @@
         "query": "success",
         "row_count": 4
       },
-      "tags": ["bql", "select"]
+      "tags": [
+        "bql",
+        "select"
+      ]
     },
     {
       "id": "bql-select-columns",
@@ -27,9 +30,17 @@
       },
       "expected": {
         "query": "success",
-        "columns": ["date", "account", "position"]
+        "columns": [
+          "date",
+          "account",
+          "position"
+        ]
       },
-      "tags": ["bql", "select", "columns"]
+      "tags": [
+        "bql",
+        "select",
+        "columns"
+      ]
     },
     {
       "id": "bql-where-account",
@@ -42,7 +53,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "where", "regex"]
+      "tags": [
+        "bql",
+        "where",
+        "regex"
+      ]
     },
     {
       "id": "bql-where-date-range",
@@ -55,7 +70,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "where", "date"]
+      "tags": [
+        "bql",
+        "where",
+        "date"
+      ]
     },
     {
       "id": "bql-where-currency",
@@ -68,7 +87,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "where", "currency"]
+      "tags": [
+        "bql",
+        "where",
+        "currency"
+      ]
     },
     {
       "id": "bql-sum-aggregation",
@@ -81,7 +104,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "aggregation", "sum"]
+      "tags": [
+        "bql",
+        "aggregation",
+        "sum"
+      ]
     },
     {
       "id": "bql-count-aggregation",
@@ -94,7 +121,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "aggregation", "count"]
+      "tags": [
+        "bql",
+        "aggregation",
+        "count"
+      ]
     },
     {
       "id": "bql-first-last",
@@ -107,7 +138,12 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "aggregation", "first", "last"]
+      "tags": [
+        "bql",
+        "aggregation",
+        "first",
+        "last"
+      ]
     },
     {
       "id": "bql-min-max",
@@ -120,7 +156,12 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "aggregation", "min", "max"]
+      "tags": [
+        "bql",
+        "aggregation",
+        "min",
+        "max"
+      ]
     },
     {
       "id": "bql-order-by-asc",
@@ -133,7 +174,10 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "order"]
+      "tags": [
+        "bql",
+        "order"
+      ]
     },
     {
       "id": "bql-order-by-desc",
@@ -146,7 +190,10 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "order"]
+      "tags": [
+        "bql",
+        "order"
+      ]
     },
     {
       "id": "bql-limit",
@@ -160,7 +207,10 @@
         "query": "success",
         "row_count": 2
       },
-      "tags": ["bql", "limit"]
+      "tags": [
+        "bql",
+        "limit"
+      ]
     },
     {
       "id": "bql-distinct",
@@ -173,7 +223,10 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "distinct"]
+      "tags": [
+        "bql",
+        "distinct"
+      ]
     },
     {
       "id": "bql-year-function",
@@ -186,7 +239,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "date"]
+      "tags": [
+        "bql",
+        "function",
+        "date"
+      ]
     },
     {
       "id": "bql-month-function",
@@ -199,7 +256,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "date"]
+      "tags": [
+        "bql",
+        "function",
+        "date"
+      ]
     },
     {
       "id": "bql-day-function",
@@ -212,7 +273,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "date"]
+      "tags": [
+        "bql",
+        "function",
+        "date"
+      ]
     },
     {
       "id": "bql-account-sortkey",
@@ -225,7 +290,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "account"]
+      "tags": [
+        "bql",
+        "function",
+        "account"
+      ]
     },
     {
       "id": "bql-root-function",
@@ -238,7 +307,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "account"]
+      "tags": [
+        "bql",
+        "function",
+        "account"
+      ]
     },
     {
       "id": "bql-parent-function",
@@ -251,7 +324,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "account"]
+      "tags": [
+        "bql",
+        "function",
+        "account"
+      ]
     },
     {
       "id": "bql-leaf-function",
@@ -264,7 +341,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "account"]
+      "tags": [
+        "bql",
+        "function",
+        "account"
+      ]
     },
     {
       "id": "bql-abs-function",
@@ -277,7 +358,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "math"]
+      "tags": [
+        "bql",
+        "function",
+        "math"
+      ]
     },
     {
       "id": "bql-neg-function",
@@ -290,7 +375,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "math"]
+      "tags": [
+        "bql",
+        "function",
+        "math"
+      ]
     },
     {
       "id": "bql-cost-function",
@@ -303,7 +392,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "cost"]
+      "tags": [
+        "bql",
+        "function",
+        "cost"
+      ]
     },
     {
       "id": "bql-convert-function",
@@ -316,7 +409,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "currency"]
+      "tags": [
+        "bql",
+        "function",
+        "currency"
+      ]
     },
     {
       "id": "bql-from-entries",
@@ -329,7 +426,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "from", "entries"]
+      "tags": [
+        "bql",
+        "from",
+        "entries"
+      ]
     },
     {
       "id": "bql-balances-target",
@@ -342,7 +443,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "target", "balances"]
+      "tags": [
+        "bql",
+        "target",
+        "balances"
+      ]
     },
     {
       "id": "bql-journal-target",
@@ -355,7 +460,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "target", "journal"]
+      "tags": [
+        "bql",
+        "target",
+        "journal"
+      ]
     },
     {
       "id": "bql-print-target",
@@ -368,7 +477,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "target", "print"]
+      "tags": [
+        "bql",
+        "target",
+        "print"
+      ]
     },
     {
       "id": "bql-alias-as",
@@ -380,9 +493,15 @@
       },
       "expected": {
         "query": "success",
-        "columns": ["acct", "total"]
+        "columns": [
+          "acct",
+          "total"
+        ]
       },
-      "tags": ["bql", "alias"]
+      "tags": [
+        "bql",
+        "alias"
+      ]
     },
     {
       "id": "bql-and-or-logic",
@@ -395,7 +514,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "where", "logic"]
+      "tags": [
+        "bql",
+        "where",
+        "logic"
+      ]
     },
     {
       "id": "bql-not-operator",
@@ -408,7 +531,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "where", "not"]
+      "tags": [
+        "bql",
+        "where",
+        "not"
+      ]
     },
     {
       "id": "bql-in-operator",
@@ -421,7 +548,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "where", "in"]
+      "tags": [
+        "bql",
+        "where",
+        "in"
+      ]
     },
     {
       "id": "bql-comparison-operators",
@@ -434,7 +565,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "where", "comparison"]
+      "tags": [
+        "bql",
+        "where",
+        "comparison"
+      ]
     },
     {
       "id": "bql-metadata-access",
@@ -447,37 +582,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "metadata"]
-    },
-    {
-      "id": "bql-tag-filter",
-      "description": "Filter by tag with HAS_TAG",
-      "spec_ref": "bql/functions.md#has-tag",
-      "skip": true,
-      "skip_reason": "has_tag function not available in beanquery - use 'trip' IN tags instead",
-      "input": {
-        "file": "fixtures/with-tags.beancount",
-        "query": "SELECT * FROM entries WHERE has_tag('trip')"
-      },
-      "expected": {
-        "query": "success"
-      },
-      "tags": ["bql", "function", "tag", "unimplemented"]
-    },
-    {
-      "id": "bql-link-filter",
-      "description": "Filter by link with MATCHES_LINK",
-      "spec_ref": "bql/functions.md#matches-link",
-      "skip": true,
-      "skip_reason": "matches_link function not available in beanquery",
-      "input": {
-        "file": "fixtures/with-links.beancount",
-        "query": "SELECT * FROM entries WHERE matches_link('invoice-*')"
-      },
-      "expected": {
-        "query": "success"
-      },
-      "tags": ["bql", "function", "link", "unimplemented"]
+      "tags": [
+        "bql",
+        "function",
+        "metadata"
+      ]
     },
     {
       "id": "bql-syntax-error",
@@ -488,9 +597,14 @@
       },
       "expected": {
         "query": "error",
-        "error_contains": ["syntax"]
+        "error_contains": [
+          "syntax"
+        ]
       },
-      "tags": ["bql", "error"]
+      "tags": [
+        "bql",
+        "error"
+      ]
     },
     {
       "id": "bql-unknown-column",
@@ -501,9 +615,14 @@
       },
       "expected": {
         "query": "error",
-        "error_contains": ["not found"]
+        "error_contains": [
+          "not found"
+        ]
       },
-      "tags": ["bql", "error"]
+      "tags": [
+        "bql",
+        "error"
+      ]
     },
     {
       "id": "bql-aggregation-without-groupby",
@@ -515,7 +634,10 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "aggregation"]
+      "tags": [
+        "bql",
+        "aggregation"
+      ]
     },
     {
       "id": "bql-empty-result",
@@ -528,7 +650,10 @@
         "query": "success",
         "row_count": 0
       },
-      "tags": ["bql", "empty"]
+      "tags": [
+        "bql",
+        "empty"
+      ]
     },
     {
       "id": "bql-having-clause",
@@ -541,22 +666,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "having", "aggregation"]
-    },
-    {
-      "id": "bql-flatten",
-      "description": "FLATTEN expands inventory positions",
-      "spec_ref": "bql/flatten.md",
-      "skip": true,
-      "skip_reason": "FLATTEN syntax not supported in beanquery",
-      "input": {
-        "file": "fixtures/with-costs.beancount",
-        "query": "SELECT account, units(sum(position)) FROM postings GROUP BY account FLATTEN"
-      },
-      "expected": {
-        "query": "success"
-      },
-      "tags": ["bql", "flatten", "unimplemented"]
+      "tags": [
+        "bql",
+        "having",
+        "aggregation"
+      ]
     },
     {
       "id": "bql-multiple-group-by",
@@ -569,7 +683,10 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "groupby"]
+      "tags": [
+        "bql",
+        "groupby"
+      ]
     },
     {
       "id": "bql-order-by-multiple",
@@ -582,22 +699,10 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "order"]
-    },
-    {
-      "id": "bql-like-operator",
-      "description": "LIKE operator for pattern matching",
-      "spec_ref": "bql/where.md#like",
-      "skip": true,
-      "skip_reason": "LIKE operator not supported in beanquery - use ~ regex instead",
-      "input": {
-        "file": "fixtures/simple-ledger.beancount",
-        "query": "SELECT * FROM postings WHERE account LIKE 'Assets:%'"
-      },
-      "expected": {
-        "query": "success"
-      },
-      "tags": ["bql", "where", "like", "unimplemented"]
+      "tags": [
+        "bql",
+        "order"
+      ]
     },
     {
       "id": "bql-between-operator",
@@ -610,7 +715,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "where", "between"]
+      "tags": [
+        "bql",
+        "where",
+        "between"
+      ]
     },
     {
       "id": "bql-null-check",
@@ -623,7 +732,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "where", "null"]
+      "tags": [
+        "bql",
+        "where",
+        "null"
+      ]
     },
     {
       "id": "bql-units-function",
@@ -636,7 +749,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "units"]
+      "tags": [
+        "bql",
+        "function",
+        "units"
+      ]
     },
     {
       "id": "bql-number-function",
@@ -649,7 +766,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "number"]
+      "tags": [
+        "bql",
+        "function",
+        "number"
+      ]
     },
     {
       "id": "bql-currency-function",
@@ -662,7 +783,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "currency"]
+      "tags": [
+        "bql",
+        "function",
+        "currency"
+      ]
     },
     {
       "id": "bql-length-function",
@@ -675,7 +800,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "string"]
+      "tags": [
+        "bql",
+        "function",
+        "string"
+      ]
     },
     {
       "id": "bql-coalesce-function",
@@ -688,7 +817,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "coalesce"]
+      "tags": [
+        "bql",
+        "function",
+        "coalesce"
+      ]
     },
     {
       "id": "bql-date-diff",
@@ -701,7 +834,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "date"]
+      "tags": [
+        "bql",
+        "function",
+        "date"
+      ]
     },
     {
       "id": "bql-today-function",
@@ -714,7 +851,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "date"]
+      "tags": [
+        "bql",
+        "function",
+        "date"
+      ]
     },
     {
       "id": "bql-quarter-function",
@@ -727,7 +868,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "date"]
+      "tags": [
+        "bql",
+        "function",
+        "date"
+      ]
     },
     {
       "id": "bql-weekday-function",
@@ -740,7 +885,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "date"]
+      "tags": [
+        "bql",
+        "function",
+        "date"
+      ]
     },
     {
       "id": "bql-open-date",
@@ -753,7 +902,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "account"]
+      "tags": [
+        "bql",
+        "function",
+        "account"
+      ]
     },
     {
       "id": "bql-close-date",
@@ -766,7 +919,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "account"]
+      "tags": [
+        "bql",
+        "function",
+        "account"
+      ]
     },
     {
       "id": "bql-open-meta",
@@ -779,22 +936,12 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "account", "metadata"]
-    },
-    {
-      "id": "bql-subaccount",
-      "description": "SUBACCOUNT extracts account component",
-      "spec_ref": "bql/functions.md#subaccount",
-      "skip": true,
-      "skip_reason": "subaccount function not available in beanquery",
-      "input": {
-        "file": "fixtures/simple-ledger.beancount",
-        "query": "SELECT subaccount(account, 0), subaccount(account, 1) FROM postings"
-      },
-      "expected": {
-        "query": "success"
-      },
-      "tags": ["bql", "function", "account", "unimplemented"]
+      "tags": [
+        "bql",
+        "function",
+        "account",
+        "metadata"
+      ]
     },
     {
       "id": "bql-grep-narration",
@@ -807,22 +954,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "string"]
-    },
-    {
-      "id": "bql-case-expression",
-      "description": "CASE expression for conditional logic",
-      "spec_ref": "bql/case.md",
-      "skip": true,
-      "skip_reason": "CASE expression not supported in beanquery",
-      "input": {
-        "file": "fixtures/simple-ledger.beancount",
-        "query": "SELECT account, CASE WHEN number > 0 THEN 'debit' ELSE 'credit' END FROM postings"
-      },
-      "expected": {
-        "query": "success"
-      },
-      "tags": ["bql", "case", "unimplemented"]
+      "tags": [
+        "bql",
+        "function",
+        "string"
+      ]
     },
     {
       "id": "bql-arithmetic-expression",
@@ -835,22 +971,10 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "arithmetic"]
-    },
-    {
-      "id": "bql-string-concat",
-      "description": "String concatenation",
-      "spec_ref": "bql/expressions.md#concat",
-      "skip": true,
-      "skip_reason": "String concatenation (||) not supported in beanquery",
-      "input": {
-        "file": "fixtures/simple-ledger.beancount",
-        "query": "SELECT account || ' - ' || currency AS label FROM postings"
-      },
-      "expected": {
-        "query": "success"
-      },
-      "tags": ["bql", "string", "concat", "unimplemented"]
+      "tags": [
+        "bql",
+        "arithmetic"
+      ]
     },
     {
       "id": "bql-type-column",
@@ -863,7 +987,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "column", "type"]
+      "tags": [
+        "bql",
+        "column",
+        "type"
+      ]
     },
     {
       "id": "bql-filename-column",
@@ -876,7 +1004,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "column", "filename"]
+      "tags": [
+        "bql",
+        "column",
+        "filename"
+      ]
     },
     {
       "id": "bql-lineno-column",
@@ -889,7 +1021,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "column", "lineno"]
+      "tags": [
+        "bql",
+        "column",
+        "lineno"
+      ]
     },
     {
       "id": "bql-flag-column",
@@ -902,7 +1038,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "column", "flag"]
+      "tags": [
+        "bql",
+        "column",
+        "flag"
+      ]
     },
     {
       "id": "bql-tags-column",
@@ -915,7 +1055,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "column", "tags"]
+      "tags": [
+        "bql",
+        "column",
+        "tags"
+      ]
     },
     {
       "id": "bql-links-column",
@@ -928,7 +1072,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "column", "links"]
+      "tags": [
+        "bql",
+        "column",
+        "links"
+      ]
     },
     {
       "id": "bql-balance-column",
@@ -941,15 +1089,16 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "column", "balance"]
+      "tags": [
+        "bql",
+        "column",
+        "balance"
+      ]
     },
     {
       "id": "bql-weight-function",
       "description": "WEIGHT function returns position weight",
       "spec_ref": "bql/functions.md#weight",
-      "skip_implementations": {
-        "beancount": "weight function not available in beanquery"
-      },
       "input": {
         "file": "fixtures/with-costs.beancount",
         "query": "SELECT account, weight(position) FROM postings"
@@ -957,7 +1106,12 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "weight", "unimplemented"]
+      "tags": [
+        "bql",
+        "function",
+        "weight",
+        "unimplemented"
+      ]
     },
     {
       "id": "bql-getprice-function",
@@ -970,7 +1124,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "function", "price"]
+      "tags": [
+        "bql",
+        "function",
+        "price"
+      ]
     },
     {
       "id": "bql-filter-by-flag",
@@ -983,7 +1141,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "where", "flag"]
+      "tags": [
+        "bql",
+        "where",
+        "flag"
+      ]
     },
     {
       "id": "bql-filter-by-type",
@@ -996,7 +1158,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "where", "type"]
+      "tags": [
+        "bql",
+        "where",
+        "type"
+      ]
     },
     {
       "id": "bql-complex-query",
@@ -1008,7 +1174,10 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "complex"]
+      "tags": [
+        "bql",
+        "complex"
+      ]
     },
     {
       "id": "bql-unknown-function",
@@ -1019,9 +1188,14 @@
       },
       "expected": {
         "query": "error",
-        "error_contains": ["no function matches"]
+        "error_contains": [
+          "no function matches"
+        ]
       },
-      "tags": ["bql", "error"]
+      "tags": [
+        "bql",
+        "error"
+      ]
     },
     {
       "id": "bql-division-by-zero",
@@ -1033,7 +1207,11 @@
       "expected": {
         "query": "success"
       },
-      "tags": ["bql", "arithmetic", "edge-case"]
+      "tags": [
+        "bql",
+        "arithmetic",
+        "edge-case"
+      ]
     }
   ]
 }

--- a/tests/beancount/v3/syntax/edge-cases/tests.json
+++ b/tests/beancount/v3/syntax/edge-cases/tests.json
@@ -349,6 +349,7 @@
     {
       "id": "mixed-whitespace",
       "description": "Transaction with mixed indentation styles",
+      "spec_ref": "lexical.md#whitespace",
       "input": {
         "inline": "2024-01-01 open Assets:A\n2024-01-01 open Assets:B\n\n2024-01-15 * \"Mixed whitespace\"\n  Assets:A  50 USD\n\tAssets:B  -50 USD"
       },
@@ -357,9 +358,7 @@
       },
       "tags": [
         "whitespace"
-      ],
-      "skip": true,
-      "skip_reason": "Mixed tab/space indentation may be implementation-specific"
+      ]
     },
     {
       "id": "comment-in-transaction",

--- a/tests/harness/runners/python/loader.py
+++ b/tests/harness/runners/python/loader.py
@@ -62,7 +62,6 @@ class TestCase:
     tags: list[str] = field(default_factory=list)
     skip: bool = False
     skip_reason: str | None = None
-    skip_implementations: dict[str, str] = field(default_factory=dict)
     suite: str = ""
 
     def get_test_type(self) -> str:
@@ -72,14 +71,6 @@ class TestCase:
         if self.expected.validate is not None:
             return "validation"
         return "syntax"
-
-    def should_skip(self, implementation: str) -> tuple[bool, str | None]:
-        """Return (skip, reason) for the given implementation."""
-        if self.skip:
-            return True, self.skip_reason
-        if implementation in self.skip_implementations:
-            return True, self.skip_implementations[implementation]
-        return False, None
 
 
 @dataclass
@@ -152,7 +143,6 @@ def load_test_suite(path: Path) -> list[TestCase]:
             tags=test_data.get("tags", []),
             skip=test_data.get("skip", False),
             skip_reason=test_data.get("skip_reason"),
-            skip_implementations=test_data.get("skip_implementations", {}),
             suite=suite_name,
         )
         tests.append(test_case)

--- a/tests/harness/runners/python/runner.py
+++ b/tests/harness/runners/python/runner.py
@@ -50,14 +50,6 @@ def run_tests(
     results = []
 
     for test in tests:
-        # Check per-implementation skip. We mutate test.skip/skip_reason so
-        # the existing executor skip check picks it up. This is scoped to
-        # the current run and isn't persisted.
-        skip, reason = test.should_skip(_implementation)
-        if skip and not test.skip:
-            test.skip = True
-            test.skip_reason = reason
-
         executor = get_executor(test)
         result = executor.execute(test)
         results.append(result)

--- a/tests/harness/runners/python/tests/test_loader.py
+++ b/tests/harness/runners/python/tests/test_loader.py
@@ -114,41 +114,6 @@ class TestTestCase:
         )
         assert tc.get_test_type() == "bql"
 
-    def test_should_skip_global(self):
-        tc = TestCase(
-            id="t",
-            description="d",
-            input=TestInput(inline="x"),
-            expected=TestExpected(),
-            base_path=Path("."),
-            skip=True,
-            skip_reason="global skip",
-        )
-        assert tc.should_skip("beancount") == (True, "global skip")
-        assert tc.should_skip("rustledger") == (True, "global skip")
-
-    def test_should_skip_per_implementation(self):
-        tc = TestCase(
-            id="t",
-            description="d",
-            input=TestInput(inline="x"),
-            expected=TestExpected(),
-            base_path=Path("."),
-            skip_implementations={"beancount": "missing feature"},
-        )
-        assert tc.should_skip("beancount") == (True, "missing feature")
-        assert tc.should_skip("rustledger") == (False, None)
-
-    def test_should_skip_none(self):
-        tc = TestCase(
-            id="t",
-            description="d",
-            input=TestInput(inline="x"),
-            expected=TestExpected(),
-            base_path=Path("."),
-        )
-        assert tc.should_skip("beancount") == (False, None)
-
 
 class TestLoadManifest:
     def test_load_manifest(self, tmp_manifest: Path):

--- a/tests/harness/test-case.schema.json
+++ b/tests/harness/test-case.schema.json
@@ -93,16 +93,11 @@
     },
     "skip": {
       "type": "boolean",
-      "description": "Whether to skip this test for all implementations"
+      "description": "Whether to skip this test"
     },
     "skip_reason": {
       "type": "string",
       "description": "Reason for skipping (if skip is true)"
-    },
-    "skip_implementations": {
-      "type": "object",
-      "description": "Per-implementation skip reasons, keyed by implementation name (e.g., 'beancount', 'rustledger')",
-      "additionalProperties": {"type": "string"}
     },
     "source": {
       "type": "object",


### PR DESCRIPTION
## Summary

The conformance suite should test the PTA spec (normative), not whatever features beanquery or Python beancount 3.x happen to implement. The previous approach conflated two distinct concerns:

1. **Conformance** — does implementation X match the spec?
2. **Feature support** — what extensions does implementation X have?

If the spec defines a feature and an implementation doesn't support it, that's a **genuine conformance failure**, not a reason to skip the test. Skipping hides non-conformance.

## Changes

### 1. Revert #34 (skip_implementations)
The per-implementation skip mechanism was wrong-headed — it papered over non-conformance rather than reporting it.

### 2. Delete 7 BQL tests for features not in the spec
`HAS_TAG`, `MATCHES_LINK`, `FLATTEN`, `SUBACCOUNT`, `CASE`, `LIKE`, `||` — none of these appear in `formats/beancount/v3/bql/functions.md`. They're beanquery extensions, not spec features, so they don't belong in a conformance suite.

### 3. Unskip 4 tests for spec-defined features
- `bql-weight-function` — `WEIGHT` is documented in `bql/functions.md`
- `booking-average-cost` — `AVERAGE` is in `spec/booking.md`
- `cost-asterisk-merge` — `{*}` is in `spec/costs.md`
- `mixed-whitespace` — `lexical.md` explicitly says "tabs and spaces MAY be mixed"

If beanquery/beancount 3.x don't implement these, that will now show as real conformance failures — which is informative and correct.

### 4. Keep 4 legitimate skips
- `account-closed-posting-same-day` — spec says UNDEFINED
- `metadata-duplicate-key` — spec says UNDEFINED
- `invalid-transaction-no-postings` — spec says UNDEFINED
- `empty-lines-in-transaction` — no spec text either way

## Before / After

| | Total | Skipped | Skip reason |
|---|---|---|---|
| Before | 281 | 15 | 11 implementation features + 4 spec undefined |
| After | 274 | 4 | 4 spec undefined |

## Expected impact

Beancount conformance may decrease (beanquery lacks WEIGHT; beancount 3.x lacks AVERAGE + {*}). That's correct — it accurately reports non-conformance. Rustledger conformance should be roughly unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)