### PR TITLE
feat: addendum section 5 — permit Unicode in account names

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -5,7 +5,8 @@
     { "pattern": "^[^h]" },
     { "pattern": "^http://localhost" },
     { "pattern": "^http://ofxhome" },
-    { "pattern": "^https://www.iso.org" }
+    { "pattern": "^https://www.iso.org" },
+    { "pattern": "^https://beancount.github.io" }
   ],
   "httpHeaders": [
     {

--- a/formats/beancount/v3/spec/addendum.md
+++ b/formats/beancount/v3/spec/addendum.md
@@ -90,6 +90,47 @@ would break existing files.
 
 ---
 
+## 5. Unicode Characters in Account Names
+
+**Beancount status**: The v3 spec requires account name components to
+start with an ASCII uppercase letter (`[A-Z]`). This restriction
+originates from the C flex lexer used in beancount v1/v2, which had
+poor Unicode support. The v3 spec codified this limitation rather than
+fixing it.
+
+This has been an open issue in upstream beancount since 2015:
+- [beancount#161](https://github.com/beancount/beancount/issues/161) — Russian (2015)
+- [beancount#398](https://github.com/beancount/beancount/issues/398) — CJK (2017)
+- [beancount#733](https://github.com/beancount/beancount/issues/733) — Chinese (2023)
+
+**PTA-standards definition**: Account name components MAY start with
+any Unicode uppercase letter (`\p{Lu}`), titlecase letter (`\p{Lt}`),
+or ideographic character (`\p{Lo}`). The ASCII-only restriction is
+removed.
+
+Valid account starts include:
+- Latin uppercase: `A-Z` (unchanged)
+- Cyrillic uppercase: `А-Я` (e.g., `Активы:Банк`)
+- Greek uppercase: `Α-Ω` (e.g., `Ενεργητικό:Τράπεζα`)
+- CJK ideographs: `漢字` (e.g., `資産:銀行口座`)
+- Other Unicode letters without case: `\p{Lo}`
+
+Subsequent characters in account components follow the same rules as
+the base spec (ASCII alphanumeric, hyphens, and UTF-8 characters).
+
+**Rationale**: There is no semantic reason to restrict account names
+to ASCII. The restriction excludes every non-Latin writing system,
+affecting users of Cyrillic, CJK, Arabic, Devanagari, and other
+scripts. Plain text accounting should be accessible to all languages.
+The `name_assets`, `name_liabilities`, etc. options already allow
+non-ASCII account type roots, making the component restriction
+inconsistent.
+
+**Test**: `unicode-account-name-edge`
+
+---
+
 ## Changelog
 
+- 2026-04-18: Add section 5 — Unicode account names
 - 2026-04-12: Initial addendum with 4 behavior definitions

--- a/tests/beancount/v3/syntax/edge-cases/tests.json
+++ b/tests/beancount/v3/syntax/edge-cases/tests.json
@@ -5,20 +5,18 @@
   "tests": [
     {
       "id": "unicode-account-name-edge",
-      "description": "Account name with Unicode characters (rejected by Beancount)",
+      "description": "Account name with CJK Unicode characters (permitted by addendum)",
+      "spec_ref": "addendum.md",
       "input": {
         "inline": "2024-01-01 open Assets:銀行口座"
       },
       "expected": {
-        "parse": "error",
-        "error_contains": [
-          "Invalid account"
-        ]
+        "parse": "success"
       },
       "tags": [
         "unicode",
         "account",
-        "invalid"
+        "addendum"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Adds section 5 to the PTA-standards addendum permitting Unicode characters at the start of account name components, removing the ASCII-only `[A-Z]` restriction from the beancount v3 spec.

## Background

The `[A-Z]` restriction is an artifact of beancount's C flex lexer — not a meaningful design choice. It's been an open issue since 2015:
- beancount/beancount#161 (Russian, 2015)
- beancount/beancount#398 (CJK, 2017)
- beancount/beancount#733 (Chinese, 2023)

Rustledger fixed this in rustledger/rustledger#817 by accepting `\p{Lu}`, `\p{Lt}`, and `\p{Lo}` characters.

## Changes

- `addendum.md`: New section 5 defining Unicode account name support
- `unicode-account-name-edge` test: flipped from `parse=error` to `parse=success`, tagged `addendum`

## Expected impact

- Rustledger: one fewer failure (this test now passes)
- Beancount: one more addendum failure (beancount still rejects Unicode starts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)