### PR TITLE
chore(ci): pin ruff and keep the formatter out of spec Markdown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,18 @@ updates:
       - "javascript"
     open-pull-requests-limit: 5
 
+  # Python (lint/format tooling, pinned in requirements-dev.txt)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps):"
+    labels:
+      - "dependencies"
+      - "python"
+    open-pull-requests-limit: 5
+
   # Python (for test harness)
   - package-ecosystem: "pip"
     directory: "/tests/harness/runners/python"

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - '**/*.py'
       - 'pyproject.toml'
+      - 'requirements-dev.txt'
       - '.github/workflows/lint-python.yml'
   pull_request:
     branches: [main]
     paths:
       - '**/*.py'
       - 'pyproject.toml'
+      - 'requirements-dev.txt'
       - '.github/workflows/lint-python.yml'
   workflow_call:
 

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install ruff
-        run: pip install ruff
+        run: pip install -r requirements-dev.txt
 
       - name: Check formatting
         run: ruff format --check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,14 @@ line-length = 100
 extend-exclude = [
     "reference/",
     "conformance/benchmarks/",
+    # Ruff 0.16 began formatting Python code blocks inside Markdown. In this
+    # repo Markdown is the deliverable, not source: the snippets are
+    # illustrative and reference types the spec defines in prose rather than
+    # in code. Restyling 41 normative documents is a decision to make on
+    # purpose, not one to inherit from a formatter upgrade. Lint and format
+    # cover real .py files; drop this line and run `ruff format .` once if the
+    # examples should follow the same style.
+    "*.md",
 ]
 
 [tool.ruff.lint]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+# Lint/format tooling, pinned so a new release cannot turn an unrelated PR red.
+# `ruff format` output is version-dependent: this repo sat five weeks between CI
+# runs, ruff shipped a new formatter style in that window, and the next PR to
+# touch anything (a markdown-only RFC) inherited 41 reformatted files it had not
+# written. Bump this deliberately, with the reformat in the same commit.
+ruff==0.16.2


### PR DESCRIPTION
`main` is red on `Lint Python / Ruff`. The commit that turned it red ([`ec3c641`](https://github.com/rustledger/pta-standards/commit/ec3c6416), the lot-ordering RFC) changed **exactly one file, and it was Markdown**.

## What happened

`pip install ruff` is unpinned, and the previous CI run was **2026-07-19**, five weeks earlier. In that gap ruff 0.16 began formatting Python code blocks **inside Markdown**. The next PR to run CI inherited the whole backlog: `41 files would be reformatted` -- none written by that PR, none of them Python.

Reproduced locally with ruff 0.16.2: identical count, 41 files, all `.md`.

## Why exclude rather than reformat

Every one of the 41 is a specification document, and the changes are styling, not correctness:

```diff
-def format_date_locale(date, locale='en_US'):
-    return babel.dates.format_date(date, format='long', locale=locale)
+def format_date_locale(date, locale="en_US"):
+    return babel.dates.format_date(date, format="long", locale=locale)

-    return ParseResult(
-        directives=ast.directives,
-        errors=ast.syntax_errors
-    )
+    return ParseResult(directives=ast.directives, errors=ast.syntax_errors)
```

In this repo Markdown is the deliverable, not source. The snippets are illustrative and reference types the spec defines in prose (`Date`, `ParseError`, `ParseResult`), and the wrapped form above is arguably the better one to read in a document. Restyling 41 normative documents is a call to make on purpose, not to inherit from a formatter upgrade.

**This is one line to reverse.** Drop `"*.md"` from `extend-exclude`, run `ruff format .` once, and the examples follow house style -- as a deliberate commit rather than a surprise.

## Coverage is unchanged for real code

| | files |
|---|---|
| `.py` in repo | 30 |
| minus existing `reference/` + `conformance/benchmarks/` excludes | **20** |
| checked by ruff after this PR | **20** |

All 20 already clean. `ruff check .` (lint) passed the whole time -- only the *formatter* ever reached into Markdown.

## The pin

`requirements-dev.txt` pins `ruff==0.16.2` and a `pip` dependabot entry for `/` bumps it weekly, so the next formatter change shows up as a reviewable PR instead of as some unrelated contributor's red build.

## Verified it still bites

Appending a badly formatted function to `tests/differential/differential.py`:

```
1 file would be reformatted, 19 files already formatted   exit=1
```

Reverting returns `20 files already formatted`. A format gate that has only ever been seen passing isn't worth much.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nNGPA44Dt32NyxWem26xr